### PR TITLE
添加限定驯服女仆数量的功能

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/capability/CapabilityOwnerMaidNumHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/capability/CapabilityOwnerMaidNumHandler.java
@@ -1,0 +1,57 @@
+package com.github.tartaricacid.touhoulittlemaid.capability;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * @author TartaricAcid
+ * @date 2019/8/28 16:34
+ **/
+public class CapabilityOwnerMaidNumHandler implements ICapabilitySerializable<NBTBase> {
+    @CapabilityInject(OwnerMaidNumHandler.class)
+    public static Capability<OwnerMaidNumHandler> OWNER_MAID_NUM_CAP = null;
+    private OwnerMaidNumHandler instance = OWNER_MAID_NUM_CAP.getDefaultInstance();
+
+    public static void register() {
+        CapabilityManager.INSTANCE.register(OwnerMaidNumHandler.class, new Capability.IStorage<OwnerMaidNumHandler>() {
+            @Override
+            public void readNBT(Capability<OwnerMaidNumHandler> capability, OwnerMaidNumHandler instance, EnumFacing side, NBTBase nbt) {
+                instance.set(((NBTTagInt) nbt).getInt());
+            }
+
+            @Override
+            public NBTBase writeNBT(Capability<OwnerMaidNumHandler> capability, OwnerMaidNumHandler instance, EnumFacing side) {
+                return new NBTTagInt(instance.get());
+            }
+        }, OwnerMaidNumHandler.FACTORY);
+    }
+
+    @Override
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+        return capability == OWNER_MAID_NUM_CAP;
+    }
+
+    @Nullable
+    @Override
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+        return capability == OWNER_MAID_NUM_CAP ? OWNER_MAID_NUM_CAP.cast(this.instance) : null;
+    }
+
+    @Override
+    public void deserializeNBT(NBTBase nbt) {
+        OWNER_MAID_NUM_CAP.getStorage().readNBT(OWNER_MAID_NUM_CAP, this.instance, null, nbt);
+    }
+
+    @Override
+    public NBTBase serializeNBT() {
+        return OWNER_MAID_NUM_CAP.getStorage().writeNBT(OWNER_MAID_NUM_CAP, this.instance, null);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/capability/OwnerMaidNumHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/capability/OwnerMaidNumHandler.java
@@ -1,0 +1,74 @@
+package com.github.tartaricacid.touhoulittlemaid.capability;
+
+import com.github.tartaricacid.touhoulittlemaid.config.GeneralConfig;
+import net.minecraft.util.math.MathHelper;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author TartaricAcid
+ * @date 2019/12/2 13:13
+ **/
+public class OwnerMaidNumHandler {
+    static OwnerMaidNumHandler.Factory FACTORY = new OwnerMaidNumHandler.Factory();
+    private int num = 0;
+    private boolean dirty;
+
+    public boolean canAdd() {
+        return this.num + 1 <= getMaxNum();
+    }
+
+    public void add() {
+        this.add(1);
+    }
+
+    public void add(int num) {
+        if (num + this.num <= getMaxNum()) {
+            this.num += num;
+        } else {
+            this.num = getMaxNum();
+        }
+        markDirty();
+    }
+
+    public void min(int num) {
+        if (num <= this.num) {
+            this.num -= num;
+        } else {
+            this.num = 0;
+        }
+        markDirty();
+    }
+
+    public void set(int num) {
+        this.num = MathHelper.clamp(num, 0, getMaxNum());
+        markDirty();
+    }
+
+    public int getMaxNum() {
+        return GeneralConfig.MAID_CONFIG.ownerMaxMaidNum;
+    }
+
+    public int get() {
+        return this.num;
+    }
+
+    public void markDirty() {
+        dirty = true;
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void setDirty(boolean dirty) {
+        this.dirty = dirty;
+    }
+
+    private static class Factory implements Callable<OwnerMaidNumHandler> {
+        @Override
+        public OwnerMaidNumHandler call() {
+            return new OwnerMaidNumHandler();
+        }
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/command/MainCommand.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/command/MainCommand.java
@@ -1,6 +1,8 @@
 package com.github.tartaricacid.touhoulittlemaid.command;
 
+import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityOwnerMaidNumHandler;
 import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityPowerHandler;
+import com.github.tartaricacid.touhoulittlemaid.capability.OwnerMaidNumHandler;
 import com.github.tartaricacid.touhoulittlemaid.capability.PowerHandler;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
@@ -44,6 +46,10 @@ public class MainCommand extends CommandBase {
                 commandPower(server, sender, args);
                 return;
             }
+            if ("maid_num".equals(args[0])) {
+                commandMaidNum(server, sender, args);
+                return;
+            }
         }
         sender.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.usage"));
     }
@@ -56,6 +62,7 @@ public class MainCommand extends CommandBase {
         switch (args.length) {
             case 1:
                 command.add("power");
+                command.add("maid_num");
                 break;
             case 2:
                 command.add("get");
@@ -94,6 +101,35 @@ public class MainCommand extends CommandBase {
             case "min":
                 power.min(num);
                 player.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.power.info", power.get()));
+                break;
+            default:
+                player.sendMessage(new TextComponentTranslation(getUsage(sender)));
+        }
+    }
+
+    private void commandMaidNum(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        EntityPlayer player = getPlayer(server, sender, args[2]);
+        OwnerMaidNumHandler numHandler = player.getCapability(CapabilityOwnerMaidNumHandler.OWNER_MAID_NUM_CAP, null);
+        int num = (args.length >= 4) ? parseInt(args[3]) : 1;
+        if (numHandler == null) {
+            return;
+        }
+
+        switch (args[1]) {
+            case "get":
+                player.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.maid_num.info", numHandler.get()));
+                break;
+            case "set":
+                numHandler.set(num);
+                player.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.maid_num.info", numHandler.get()));
+                break;
+            case "add":
+                numHandler.add(num);
+                player.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.maid_num.info", numHandler.get()));
+                break;
+            case "min":
+                numHandler.min(num);
+                player.sendMessage(new TextComponentTranslation("commands.touhou_little_maid.main.maid_num.info", numHandler.get()));
                 break;
             default:
                 player.sendMessage(new TextComponentTranslation(getUsage(sender)));

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/config/GeneralConfig.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/config/GeneralConfig.java
@@ -72,6 +72,12 @@ public class GeneralConfig {
         @Config.LangKey("config.touhou_little_maid.maid_config.maid_cannot_change_model")
         @Config.Name("MaidCannotChangeModel")
         public boolean maidCannotChangeModel = false;
+
+        @Config.Comment("The maximum number of maids the player own.")
+        @Config.LangKey("config.touhou_little_maid.maid_config.owner_max_maid_num")
+        @Config.Name("OwnerMaxMaidNum")
+        @Config.RangeInt(min = 0)
+        public int ownerMaxMaidNum = Integer.MAX_VALUE;
     }
 
     public static class VanillaConfig {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
@@ -7,6 +7,8 @@ import com.github.tartaricacid.touhoulittlemaid.api.LittleMaidAPI;
 import com.github.tartaricacid.touhoulittlemaid.api.MaidInventory;
 import com.github.tartaricacid.touhoulittlemaid.api.util.BaubleItemHandler;
 import com.github.tartaricacid.touhoulittlemaid.block.BlockGarageKit;
+import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityOwnerMaidNumHandler;
+import com.github.tartaricacid.touhoulittlemaid.capability.OwnerMaidNumHandler;
 import com.github.tartaricacid.touhoulittlemaid.client.model.EntityModelJson;
 import com.github.tartaricacid.touhoulittlemaid.config.GeneralConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.ai.*;
@@ -713,15 +715,20 @@ public class EntityMaid extends AbstractEntityMaid {
         Item tamedItem = Item.getByNameOrId(GeneralConfig.MAID_CONFIG.maidTamedItem) == null ? Items.CAKE : Item.getByNameOrId(GeneralConfig.MAID_CONFIG.maidTamedItem);
         boolean isReloadTamedCondition = itemstack.getItem() == Item.getItemFromBlock(Blocks.STRUCTURE_VOID);
         boolean isNormalTamedCondition = !this.isTamed() && itemstack.getItem() == tamedItem;
-        if (isReloadTamedCondition || isNormalTamedCondition) {
-            if (!world.isRemote) {
+        boolean isTamedCondition = isReloadTamedCondition || isNormalTamedCondition;
+        OwnerMaidNumHandler num = player.getCapability(CapabilityOwnerMaidNumHandler.OWNER_MAID_NUM_CAP, null);
+        if (!world.isRemote && isTamedCondition && num != null) {
+            if (num.canAdd()) {
                 consumeItemFromStack(player, itemstack);
                 this.setTamedBy(player);
                 this.playTameEffect(true);
                 this.getNavigator().clearPath();
                 this.world.setEntityState(this, (byte) 7);
                 this.playSound(MaidSoundEvent.MAID_TAMED, 1, 1);
+                num.add();
                 return true;
+            } else {
+                player.sendMessage(new TextComponentTranslation("message.touhou_little_maid.owner_maid_num.can_not_add", num.get(), num.getMaxNum()));
             }
         }
         return false;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/network/simpleimpl/SyncOwnerMaidNumMessage.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/network/simpleimpl/SyncOwnerMaidNumMessage.java
@@ -1,0 +1,61 @@
+package com.github.tartaricacid.touhoulittlemaid.network.simpleimpl;
+
+import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityOwnerMaidNumHandler;
+import com.github.tartaricacid.touhoulittlemaid.capability.OwnerMaidNumHandler;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+/**
+ * @author TartaricAcid
+ * @date 2019/8/28 17:27
+ **/
+public class SyncOwnerMaidNumMessage implements IMessage {
+    private int num;
+
+    public SyncOwnerMaidNumMessage() {
+    }
+
+    public SyncOwnerMaidNumMessage(int num) {
+        this.num = num;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.num = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(num);
+    }
+
+    public int getNum() {
+        return num;
+    }
+
+    public static class Handler implements IMessageHandler<SyncOwnerMaidNumMessage, IMessage> {
+        @Override
+        @SideOnly(Side.CLIENT)
+        public IMessage onMessage(SyncOwnerMaidNumMessage message, MessageContext ctx) {
+            if (ctx.side == Side.CLIENT) {
+                Minecraft.getMinecraft().addScheduledTask(() -> {
+                    EntityPlayer player = Minecraft.getMinecraft().player;
+                    if (player == null) {
+                        return;
+                    }
+                    OwnerMaidNumHandler num = player.getCapability(CapabilityOwnerMaidNumHandler.OWNER_MAID_NUM_CAP, null);
+                    if (num != null) {
+                        num.set(message.getNum());
+                    }
+                });
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/proxy/CommonProxy.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/proxy/CommonProxy.java
@@ -5,6 +5,7 @@ import com.github.tartaricacid.touhoulittlemaid.api.LittleMaidAPI;
 import com.github.tartaricacid.touhoulittlemaid.api.util.ItemDefinition;
 import com.github.tartaricacid.touhoulittlemaid.bauble.*;
 import com.github.tartaricacid.touhoulittlemaid.block.muiltblock.MuiltBlockAltar;
+import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityOwnerMaidNumHandler;
 import com.github.tartaricacid.touhoulittlemaid.capability.CapabilityPowerHandler;
 import com.github.tartaricacid.touhoulittlemaid.client.resources.pojo.CustomModelPackPOJO;
 import com.github.tartaricacid.touhoulittlemaid.command.MainCommand;
@@ -110,6 +111,7 @@ public class CommonProxy {
     public void init(FMLInitializationEvent event) {
         NetworkRegistry.INSTANCE.registerGuiHandler(TouhouLittleMaid.INSTANCE, new MaidGuiHandler());
         CapabilityPowerHandler.register();
+        CapabilityOwnerMaidNumHandler.register();
         CustomSpellCardManger.onCustomSpellCardReload();
         if (Loader.isModLoaded("patchouli")) {
             MultiblockRegistry.init();
@@ -242,6 +244,7 @@ public class CommonProxy {
         INSTANCE.registerMessage(ClientEffectHandler.class, EffectReply.class, 13, Side.CLIENT);
         INSTANCE.registerMessage(BeaconAbsorbMessage.Handler.class, BeaconAbsorbMessage.class, 14, Side.CLIENT);
         INSTANCE.registerMessage(SyncCustomSpellCardData.Handler.class, SyncCustomSpellCardData.class, 15, Side.CLIENT);
+        INSTANCE.registerMessage(SyncOwnerMaidNumMessage.Handler.class, SyncOwnerMaidNumMessage.class, 16, Side.CLIENT);
     }
 
     /**

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.lang
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.lang
@@ -44,8 +44,9 @@ tile.touhou_little_maid.tombstone.name=Tombstone
 # Command
 commands.touhou_little_maid.hata.usage=§cUsage: /hata <reload>
 commands.touhou_little_maid.hata.reload=Has reloaded all hata texture
-commands.touhou_little_maid.main.usage=§cUsage: /touhou_little_maid <power> <get|set|add|min> <player> [value]
+commands.touhou_little_maid.main.usage=§cUsage: /touhou_little_maid <power|maid_num> <get|set|add|min> <player> [value]
 commands.touhou_little_maid.main.power.info=Current Power: %.2f
+commands.touhou_little_maid.main.maid_num.info=Current Maid Num: %d
 commands.touhou_little_maid.spell_card.usage=§cUsage: /spell_card <reload>
 commands.touhou_little_maid.spell_card.reload=Has reloaded all custom spell card
 
@@ -95,12 +96,13 @@ message.touhou_little_maid.tombstone.on_block_activated=Tombstone Has Been Taken
 message.touhou_little_maid.missing_patchouli=[{"text":"[Touhou Little Maid] ","color":"green","bold":true},{"text":"Click Here","color":"gold","underlined":true,"bold":false,"clickEvent":{"action":"open_url","value":"https://www.curseforge.com/minecraft/mc-mods/patchouli"},"hoverEvent":{"action":"show_text","value":"https://www.curseforge.com/minecraft/mc-mods/patchouli"}},{"text":" To Install Patchouli Mod To Get The Manual","color":"yellow","bold":false}]
 message.touhou_little_maid.broom.message=Only creative mode player can ride it, but you can disable it by modifying the configuration.
 message.touhou_little_maid.debug_danmaku.type=Current Type: %s
+message.touhou_little_maid.owner_maid_num.can_not_add=You can no longer tame maids, you have reached the limit (%d/%d)
 
 # Info
 info.touhou_little_maid.maid.unset_pos=§6§lUnset Pos
 info.touhou_little_maid.maid.set_pos=§a§lMaid Pos: %d, %d, %d
 
-# Main Config
+# Maid Config
 config.touhou_little_maid.maid_config=Maid Config
 config.touhou_little_maid.maid_config.maid_tamed_item=Maid Tamed Item
 config.touhou_little_maid.maid_config.maid_temptation_item=Maid Temptation Item
@@ -110,6 +112,7 @@ config.touhou_little_maid.maid_config.maid_hurt_sound_interval=Maid Hurt Sound I
 config.touhou_little_maid.maid_config.maid_always_show_hat=Maid Always Show Hat
 config.touhou_little_maid.maid_config.enabled_tasks=Maid Enabled Tasks
 config.touhou_little_maid.maid_config.maid_cannot_change_model=Can Player Change Maid Skin
+config.touhou_little_maid.maid_config.owner_max_maid_num=Owner Max Maid Num
 
 # Vanilla Config
 config.touhou_little_maid.vanilla_config=Vanilla Config

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.lang
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.lang
@@ -44,8 +44,9 @@ tile.touhou_little_maid.tombstone.name=墓碑
 # Command
 commands.touhou_little_maid.hata.usage=§c用法：/hata <reload>
 commands.touhou_little_maid.hata.reload=已经重载所有的旗指物材质
-commands.touhou_little_maid.main.usage=§c用法：/touhou_little_maid <power> <get|set|add|min> <玩家> [数值]
+commands.touhou_little_maid.main.usage=§c用法：/touhou_little_maid <power|maid_num> <get|set|add|min> <玩家> [数值]
 commands.touhou_little_maid.main.power.info=当前 Power 数：%.2f
+commands.touhou_little_maid.main.maid_num.info=当前女仆数：%d
 commands.touhou_little_maid.spell_card.usage=§c用法：/spell_card <reload>
 commands.touhou_little_maid.spell_card.reload=已经重载所有的符卡
 
@@ -95,12 +96,13 @@ message.touhou_little_maid.tombstone.on_block_activated=墓碑已经被收回！
 message.touhou_little_maid.missing_patchouli=[{"text":"[Touhou Little Maid] ","color":"green","bold":true},{"text":"点击此处","color":"gold","underlined":true,"bold":false,"clickEvent":{"action":"open_url","value":"https://www.curseforge.com/minecraft/mc-mods/patchouli"},"hoverEvent":{"action":"show_text","value":"https://www.curseforge.com/minecraft/mc-mods/patchouli"}},{"text":"安装帕秋莉模组来获取手册","color":"yellow","bold":false}]
 message.touhou_little_maid.broom.message=只有创造模式玩家可以骑乘，但是你可以修改配置文件关闭此限制
 message.touhou_little_maid.debug_danmaku.type=当前类型：%s
+message.touhou_little_maid.owner_maid_num.can_not_add=你无法再驯服女仆，你已经达到了上限（%d/%d）
 
 # Info
 info.touhou_little_maid.maid.unset_pos=§6§l未设置坐标
 info.touhou_little_maid.maid.set_pos=§a§l女仆坐标：%d，%d，%d
 
-# Main Config
+# Maid Config
 config.touhou_little_maid.maid_config=女仆相关配置
 config.touhou_little_maid.maid_config.maid_tamed_item=驯服女仆所使用的物品
 config.touhou_little_maid.maid_config.maid_temptation_item=诱惑女仆所使用的物品
@@ -110,6 +112,7 @@ config.touhou_little_maid.maid_config.maid_hurt_sound_interval=女仆受伤的�
 config.touhou_little_maid.maid_config.maid_always_show_hat=女仆总是显示帽子
 config.touhou_little_maid.maid_config.enabled_tasks=女仆启用的模式
 config.touhou_little_maid.maid_config.maid_cannot_change_model=玩家能否改变女仆皮肤
+config.touhou_little_maid.maid_config.owner_max_maid_num=可驯服的最大女仆数
 
 # Vanilla Config
 config.touhou_little_maid.vanilla_config=原版相关配置


### PR DESCRIPTION
- 通过配置文件限定玩家最大驯服女仆数
- 添加相关的指令，可以随时设置指定玩家的女仆数记录