### PR TITLE
增强攻击AI判断

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,11 @@ repositories {
     maven {
         // HWYLA
         name = "Tehnut Maven"
-        url = "http://tehnut.info/maven"
+        url = "https://maven.tehnut.info/"
     }
     maven {
         // The One Probe
+        //https://maven.tterrag.com/mcjty/theoneprobe/TheOneProbe-1.12/1.12-1.4.22-13/TheOneProbe-1.12-1.12-1.4.22-13.pom
         name = 'tterrag maven'
         url = "http://maven.tterrag.com/"
     }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/AbstractEntityMaid.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/AbstractEntityMaid.java
@@ -4,11 +4,15 @@ import com.github.tartaricacid.touhoulittlemaid.api.util.BaubleItemHandler;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.IRangedAttackMob;
 import net.minecraft.entity.passive.EntityTameable;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.CooldownTracker;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * @author Snownee
@@ -18,6 +22,13 @@ public abstract class AbstractEntityMaid extends EntityTameable implements IRang
     public AbstractEntityMaid(World worldIn) {
         super(worldIn);
     }
+
+    /**
+     * 获取女仆的当前AI的UID
+     *
+     * @return AI的UID
+     */
+    abstract public ResourceLocation getTaskUid();
 
     /**
      * 获取女仆的饰品栏
@@ -41,6 +52,15 @@ public abstract class AbstractEntityMaid extends EntityTameable implements IRang
      * @return IItemHandlerModifiable 对象
      */
     abstract public IItemHandlerModifiable getInv(MaidInventory type);
+
+    /**
+     * 判断主手物品是否满足条件，否则寻找优先级最大的物品交换到主手
+     *
+     * @param itemRule        如果主手满足条件，则无需交换
+     * @param priorityHandler 如果主手不满足条件，则交换。优先级大于0才是有效物品，寻找优先级最大的物品
+     * @return 返回true主手物品已符合条件，反之false
+     */
+    abstract public boolean MoveItemsToMainhandForMaxPriority(Predicate<ItemStack> itemRule, Function<ItemStack, Integer> priorityHandler);
 
     /**
      * 女仆能否破坏方块

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/EntityMaidAttack.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/EntityMaidAttack.java
@@ -1,10 +1,16 @@
 package com.github.tartaricacid.touhoulittlemaid.entity.ai;
 
 import com.github.tartaricacid.touhoulittlemaid.api.AbstractEntityMaid;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIAttackMelee;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemSword;
 
 public class EntityMaidAttack extends EntityAIAttackMelee {
     private final AbstractEntityMaid entityMaid;
+    //切换武器的CD，女仆换武器就不用时间了吗？？！！
+    private int pickUpItemCoolDown = 0;
 
     public EntityMaidAttack(AbstractEntityMaid entityMaid, double speedIn, boolean longMemoryIn) {
         super(entityMaid, speedIn, longMemoryIn);
@@ -13,7 +19,55 @@ public class EntityMaidAttack extends EntityAIAttackMelee {
 
     @Override
     public boolean shouldExecute() {
-        return !entityMaid.isSitting() && super.shouldExecute();
+        //切换武器的冷却时间
+        if (pickUpItemCoolDown > 0) {
+            pickUpItemCoolDown--;
+        }
+        //女仆没有待命时才能寻找物品栏更换武器
+        if (!entityMaid.isSitting()) {
+            //判断当前是否有攻击对象，以及对象是否存活
+            EntityLivingBase attackTarget = entityMaid.getAttackTarget();
+            if (attackTarget != null && attackTarget.isEntityAlive()) {
+                boolean hasSword;
+                //切换武器冷却完毕，切换武器冷却同时也是为了减少高频遍历物品
+                if (pickUpItemCoolDown <= 0) {
+                    //判断当前是否持有剑类攻击武器
+                    //寻找伤害最高的剑类攻击武器
+                    //交换物品到主手
+                    hasSword = entityMaid.MoveItemsToMainhandForMaxPriority(i -> swordWeight(i) > 0, this::swordWeight);
+                } else {
+                    hasSword = swordWeight(entityMaid.getHeldItemMainhand()) > 0;
+                }
+                if (!hasSword) {
+                    //没有武器难道赤手空拳去打吗？
+                    if (pickUpItemCoolDown > 0) {
+                        //着急换武器
+                        pickUpItemCoolDown = pickUpItemCoolDown - 4;
+                    }
+                    return false;
+                } else {
+                    //在打人不得冷却一下？差不多128个红石刻？2秒？
+                    pickUpItemCoolDown = 128;
+                    return super.shouldExecute();
+                }
+            }
+        }
+        return false;
+    }
+
+    //计算该物品作为剑类武器的比重，0为不适合
+    private int swordWeight(ItemStack itemStack) {
+        Item item = itemStack.getItem();
+        if (item instanceof ItemSword) {
+            ItemSword sword = (ItemSword) item;
+            //确保分母不会为0，即使好像是多余的代码
+            int effectiveDamage = Math.max(itemStack.getMaxDamage() - itemStack.getItemDamage(), 1);
+            //高优先高攻击力武器，除非有个耐久剩余不多，先用先清背包
+            float weight = 10000 * (sword.getAttackDamage() + 4) / (effectiveDamage + 7000);
+            //冷不防有人给你无限攻击力呢？
+            return weight < 0 ? Integer.MAX_VALUE : Math.round(weight);
+        }
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
修正一处网址错误
（http://tehnut.info/maven是打不开的，https://maven.tehnut.info/才是正确地址，四个小时过去了，部署项目不成功就因为这！）
添加查询当前AI类型接口，添加查询物品交换到主手接口
（弓和御币逻辑是共用的，代码没有判断是弓还是御币，导致持弓射弹幕，持御币射箭= =）
修复远程攻击没有判断模式正确，增加切换主手武器CD，增加从背包拾取武器逻辑
（高频遍历背包是不友好的行为，设置了一个cd，在小服务器上，可能会更久无法成功切换）

从下载源码到现在24个小时还不到= =
这也是我第一次写mc的mod
注释尽量都加上了，代码上也写得尽力，不周的地方大佬就随便看看吧
呃，其实还有很多地方没弄明白（雾