### PR TITLE
修复一些实体的碰撞与Sponge的兼容问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/AbstractEntityFromItem.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/AbstractEntityFromItem.java
@@ -17,6 +17,7 @@ import net.minecraftforge.items.IItemHandler;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * @author TartaricAcid
@@ -116,6 +117,32 @@ public abstract class AbstractEntityFromItem extends EntityLivingBase {
     @Override
     public boolean attackable() {
         return false;
+    }
+
+    /**
+     * 应用实体挤压伤害判断相关逻辑
+     * @param entities 将要被检测的实体
+     */
+    protected void applyEntityCrammingDamage(List<Entity> entities) {
+        // 与父类相关逻辑类似
+        if (entities.isEmpty())
+            return;
+
+        int maxEntityCramming = this.world.getGameRules().getInt("maxEntityCramming");
+
+        if (maxEntityCramming > 0 && entities.size() > maxEntityCramming - 1 && this.rand.nextInt(4) == 0) {
+            int collidableEntities = 0;
+
+            for (int i = 0; i < entities.size(); i++) {
+                if (entities.get(i).isRiding()) {
+                    collidableEntities++;
+                }
+            }
+
+            if (collidableEntities > maxEntityCramming) {
+                this.attackEntityFrom(DamageSource.CRAMMING, 6.0F);
+            }
+        }
     }
 
     // ------------ EntityLivingBase 要求实现的几个抽象方法，因为全用不上，故返回默认值 ----------- //

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityBox.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityBox.java
@@ -74,7 +74,7 @@ public class EntityBox extends Entity {
     }
 
     private void collideWithNearbyEntities() {
-        List<Entity> list = this.world.getEntitiesWithinAABB(EntityTameable.class, this.getEntityBoundingBox().shrink(1));
+        List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox().shrink(1));
         if (list.isEmpty()) {
             return;
         }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityChair.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityChair.java
@@ -91,11 +91,15 @@ public class EntityChair extends AbstractEntityFromItem {
 
     @Override
     protected void collideWithNearbyEntities() {
-        super.collideWithNearbyEntities();
-        List<Entity> list = this.world.getEntitiesWithinAABB(EntityTameable.class, this.getEntityBoundingBox().expand(0, 0.5, 0));
+        // super.collideWithNearbyEntities(); // 减少一次对getEntitiesInAABBexcluding的调用
+        List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox().expand(0, 0.5, 0));
         if (list.isEmpty()) {
             return;
         }
+
+        // 应用实体挤压伤害
+        applyEntityCrammingDamage(list);
+
         // 遍历进行乘坐判定
         for (Entity entity : list) {
             // 如果选择的实体不是已经坐上去的乘客

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityMaidVehicle.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityMaidVehicle.java
@@ -107,11 +107,15 @@ public class EntityMaidVehicle extends AbstractEntityFromItem implements IEntity
 
     @Override
     protected void collideWithNearbyEntities() {
-        super.collideWithNearbyEntities();
-        List<Entity> list = this.world.getEntitiesWithinAABB(EntityTameable.class, this.getEntityBoundingBox().expand(0, 0.5, 0));
+        // super.collideWithNearbyEntities(); // 减少一次对getEntitiesInAABBexcluding的调用
+        List<Entity> list = this.world.getEntitiesWithinAABBExcludingEntity(this, this.getEntityBoundingBox().expand(0, 0.5, 0));
         if (list.isEmpty()) {
             return;
         }
+
+        // 应用实体挤压伤害
+        applyEntityCrammingDamage(list);
+
         // 遍历进行乘坐判定
         for (Entity entity : list) {
             // 如果选择的实体不是已经坐上去的乘客


### PR DESCRIPTION
喜欢的mod不能兼容最新的Sponge很难受呢=v=，Sponge对```World.getEntitiesWithinAABB```方法进行了修改([相关代码](https://github.com/SpongePowered/Sponge/blob/stable-7/src/main/java/org/spongepowered/common/mixin/core/world/WorldServerMixin.java#L1707))，之后对实体碰撞部分进行了一定修改(SpongePowered/Sponge#2453)，导致了在```EntityLivingBase```的子类在```collideWithNearbyEntities```被调用时不能正常调用```World.getEntitiesWithinAABB```方法，而```World.getEntitiesWithinAABBExcludingEntity```未被修改，因此我们只要在实体碰撞时避开调用```World.getEntitiesWithinAABB```即可，对目前的实现来说这种修改没有影响