### PR TITLE
手持拔刀剑时无法拆卸稻草人，修复利用拆卸稻草人获取拔刀剑杀敌数

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityScarecrow.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityScarecrow.java
@@ -48,6 +48,15 @@ public class EntityScarecrow extends AbstractEntityFromItem {
 
     @Override
     protected boolean canKillEntity(EntityPlayer player) {
+        if (!(player.getHeldItemMainhand().isEmpty())) {
+            ItemStack mainHandItem = player.getHeldItemMainhand();
+            if (mainHandItem.hasTagCompound()) {
+                NBTTagCompound tag = mainHandItem.getTagCompound();
+                if (tag.hasKey("SlashBlade")) {
+                    return false;
+                }
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
### 问题描述

玩家 `Shift+左键点击` 拆卸稻草人时，如果主手手持拔刀剑，拔刀剑会获得 1 点杀敌数。

### 本 PR 实现的功能

使玩家在主手持有拔刀剑时，无法拆卸稻草人，从而解决上述问题。
