### PR TITLE
fix unnecessary schedule update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out
 *.iml
 .idea
 
+# vscode
+.vscode
+
 # gradle
 build
 .gradle

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/SchedulePos.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/SchedulePos.java
@@ -54,7 +54,7 @@ public final class SchedulePos {
     }
 
     public void tick(EntityMaid maid) {
-        if (maid.isHomeModeEnable() && maid.tickCount % 40 == 0) {
+        if (maid.tickCount % 40 == 0) {
             this.restrictTo(maid);
             if (maid.isWithinRestriction()) {
                 return;
@@ -95,6 +95,9 @@ public final class SchedulePos {
     }
 
     public void restrictTo(EntityMaid maid) {
+        if (!maid.isHomeModeEnable()) {
+            return;
+        }
         Activity activity = maid.getScheduleDetail();
         if (activity == Activity.WORK) {
             maid.restrictTo(this.workPos, MaidConfig.MAID_WORK_RANGE.get());

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/SchedulePos.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/SchedulePos.java
@@ -54,7 +54,7 @@ public final class SchedulePos {
     }
 
     public void tick(EntityMaid maid) {
-        if (maid.tickCount % 40 == 0) {
+        if (maid.isHomeModeEnable() && maid.tickCount % 40 == 0) {
             this.restrictTo(maid);
             if (maid.isWithinRestriction()) {
                 return;


### PR DESCRIPTION
原来的 `EntityMaid.aiStep()` 调用的 `this.schedulePos.tick(this)` 每40刻会调用一次 `this.restrictTo(maid)` ，而这个方法无论女仆是否在Home模式都会将女仆的 `RESTRICT_RADIUS` 设置成Home模式下当前时间工作状态对应的活动范围半径（ `MAID_xxx_RADIUS` ），导致 `MAID_NON_HOME_RANGE` 不起作用。也就是说，当 `MAID_xxx_RADIUS(WORK/IDLE/SLEEP)` 设置得很大时，无论 `MAID_NON_HOME_RANGE` 是多少女仆都不会近距离跟随主人。

而且在非Home模式下原来的 `this.schedulePos.tick(this)` 在每次调用 `this.restrictTo(maid)` 之后因为女仆在非Home模式下 `maid.isWithinRestriction()` 必为 `true` 而立即返回，因此在非Home模式下 `this.schedulePos.tick(this)` 的作用就是调用了一次多余的 `this.restrictTo(maid)` 。那么在判断tick数是否为40的倍数的时候再判断一下女仆是否在Home模式下就可以解决这个问题了。