### PR TITLE
一些小修改

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,10 @@ dependencies {
     // at runtime, use the full JEI jar for Forge
     runtimeOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
 
+    // rei
+    runtimeOnly fg.deobf("curse.maven:architectury-api-419699:${architectury_api_id}")
+    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
+
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ catalogue_id=4766090
 bookshelf_id=5084135
 enchantment_descriptions_id=5136988
 tacz_version=1.0.0-beta
+architectury_api_id=5137938
+rei_version=12.1.725

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
@@ -186,8 +186,8 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
         renderTransTooltip(modelDownload, graphics, x, y, "gui.touhou_little_maid.button.model_download");
         renderTransTooltip(skin, graphics, x, y, "gui.touhou_little_maid.button.skin");
         renderTransTooltip(sound, graphics, x, y, "gui.touhou_little_maid.button.sound");
-        renderTransTooltip(pageUp, graphics, x, y, "gui.touhou_little_maid.task.next_page");
-        renderTransTooltip(pageDown, graphics, x, y, "gui.touhou_little_maid.task.previous_page");
+        renderTransTooltip(pageUp, graphics, x, y, "gui.touhou_little_maid.task.previous_page");
+        renderTransTooltip(pageDown, graphics, x, y, "gui.touhou_little_maid.task.next_page");
         renderTransTooltip(pageClose, graphics, x, y, "gui.touhou_little_maid.task.close");
         renderTransTooltip(taskSwitch, graphics, x, y, "gui.touhou_little_maid.task.switch");
         renderMaidInfo(graphics, x, y);
@@ -351,7 +351,7 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
 
     private void drawTaskPageCount(GuiGraphics graphics) {
         if (taskListOpen) {
-            String text = String.format("%d/%d", TASK_PAGE + 1, TaskManager.getTaskIndex().size() / TASK_COUNT_PER_PAGE + 1);
+            String text = String.format("%d/%d", TASK_PAGE + 1, (TaskManager.getTaskIndex().size() - 1) / TASK_COUNT_PER_PAGE + 1);
             graphics.drawString(font, text, -48, 12, 0x333333, false);
         }
     }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/cloth/MenuIntegration.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/cloth/MenuIntegration.java
@@ -19,9 +19,7 @@ import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class MenuIntegration {
@@ -146,6 +144,19 @@ public class MenuIntegration {
                 .setSaveConsumer(l -> {
                     MaidConfig.MAID_HEAL_MEALS_BLOCK_LIST_REGEX.set(l);
                     MaidMealRegConfigEvent.handleConfig(MaidConfig.MAID_HEAL_MEALS_BLOCK_LIST_REGEX.get(), MaidMealRegConfigEvent.HEAL_MEAL_REGEX);
+                }).build());
+
+        maid.addEntry(entryBuilder.startStrList(Component.translatable("config.touhou_little_maid.maid.maid_eaten_return_container_list.name"), MaidConfig.MAID_EATEN_RETURN_CONTAINER_LIST.get().stream().map(s -> s.get(0) + "," + s.get(1)).toList())
+                .setDefaultValue(MaidConfig.MAID_EATEN_RETURN_CONTAINER_LIST.getDefault().stream().map(s -> s.get(0) + "," + s.get(1)).toList())
+                .setTooltip(Component.translatable("config.touhou_little_maid.maid.maid_eaten_return_container_list.desc"))
+                .setSaveConsumer(l -> {
+                    List<List<String>> maidMealContainerList = new ArrayList<>();
+                    for (String s : l) {
+                        String[] split = s.split(",");
+                        if (split.length != 2) continue;
+                        maidMealContainerList.add(Arrays.asList(split[0], split[1]));
+                    }
+                    MaidConfig.MAID_EATEN_RETURN_CONTAINER_LIST.set(maidMealContainerList);
                 }).build());
     }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
@@ -1,0 +1,34 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.rei;
+
+import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
+import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import me.shedaniel.rei.api.client.registry.entry.CollapsibleEntryRegistry;
+import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes;
+import me.shedaniel.rei.forge.REIPluginClient;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@REIPluginClient
+public class MaidREIClientPlugin implements REIClientPlugin {
+
+    /**
+     * Registers entries to collapse on the entry panel.
+     *
+     * @param registry the collapsible entry registry
+     */
+    @SuppressWarnings("UnstableApiUsage")
+    @Override
+    public void registerCollapsibleEntries(CollapsibleEntryRegistry registry) {
+        List<Item> groupItems = new ArrayList<>();
+        groupItems.add(InitItems.GARAGE_KIT.get());
+        groupItems.add(InitItems.CHAIR.get());
+        for (Item item : groupItems) {
+            ResourceLocation groupId = ForgeRegistries.ITEMS.getKey(item);
+            registry.group(groupId, item.getDescription(), VanillaEntryTypes.ITEM, (entryStack) -> entryStack.getValue().is(item));
+        }
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/config/subconfig/MaidConfig.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/config/subconfig/MaidConfig.java
@@ -1,14 +1,12 @@
 package com.github.tartaricacid.touhoulittlemaid.config.subconfig;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
+
+import static com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil.getItemId;
 
 public final class MaidConfig {
     public static final String TAG_PREFIX = "#";
@@ -35,6 +33,7 @@ public final class MaidConfig {
     public static ForgeConfigSpec.ConfigValue<List<String>> MAID_WORK_MEALS_BLOCK_LIST_REGEX;
     public static ForgeConfigSpec.ConfigValue<List<String>> MAID_HOME_MEALS_BLOCK_LIST_REGEX;
     public static ForgeConfigSpec.ConfigValue<List<String>> MAID_HEAL_MEALS_BLOCK_LIST_REGEX;
+    public static ForgeConfigSpec.ConfigValue<List<List<String>>> MAID_EATEN_RETURN_CONTAINER_LIST;
 
     public static void init(ForgeConfigSpec.Builder builder) {
         builder.push("maid");
@@ -119,12 +118,14 @@ public final class MaidConfig {
         MAID_HEAL_MEALS_BLOCK_LIST_REGEX = builder.define("MaidHealMealsBlockListRegEx", Lists.newArrayList(
         ));
 
-        builder.pop();
-    }
+        builder.comment("These entries configure the container returned after a maid has eaten", "Eg: [\"minecraft:beetroot_soup\", \"minecraft:bowl\"]");
+        // 不知道原版碗类食物要不要走进配置？就干脆不走了
+        MAID_EATEN_RETURN_CONTAINER_LIST = builder.define("MaidEatenReturnContainerList", Lists.newArrayList(
+//                Arrays.asList(getItemId(Items.MUSHROOM_STEW), getItemId(Items.BOWL)),
+//                Arrays.asList(getItemId(Items.BEETROOT_SOUP), getItemId(Items.BOWL)),
+//                Arrays.asList(getItemId(Items.RABBIT_STEW), getItemId(Items.BOWL))
+        ));
 
-    private static String getItemId(Item item) {
-        ResourceLocation key = ForgeRegistries.ITEMS.getKey(item);
-        Preconditions.checkNotNull(key);
-        return key.toString();
+        builder.pop();
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/event/food/DefaultEatenEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/event/food/DefaultEatenEvent.java
@@ -1,14 +1,18 @@
 package com.github.tartaricacid.touhoulittlemaid.event.food;
 
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
 import com.github.tartaricacid.touhoulittlemaid.api.event.MaidAfterEatEvent;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.CombinedInvWrapper;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
 
@@ -26,7 +30,7 @@ public class DefaultEatenEvent {
                 String itemId = ItemsUtil.getItemId(foodAfterEat.getItem());
                 for (List<String> strings : MAID_EATEN_RETURN_CONTAINER_LIST.get()) {
                     if (strings.get(0).equals(itemId)) {
-                        craftingRemainingItem = ItemsUtil.getItemStack(strings.get(1));
+                        craftingRemainingItem = getItemStack(strings.get(1));
                         break;
                     }
                 }
@@ -42,6 +46,17 @@ public class DefaultEatenEvent {
                     maid.level.addFreshEntity(itemEntity);
                 }
             }
+        }
+    }
+
+    private static ItemStack getItemStack(String itemId) {
+        ResourceLocation resourceLocation = new ResourceLocation(itemId);
+        Item value = ForgeRegistries.ITEMS.getValue(resourceLocation);
+        if (value != null) {
+            return new ItemStack(value);
+        }else {
+            TouhouLittleMaid.LOGGER.warn("Can't find item: " + itemId + ", please check your MaidEatenReturnContainerList config entry.");
+            return ItemStack.EMPTY;
         }
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/event/food/DefaultEatenEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/event/food/DefaultEatenEvent.java
@@ -2,12 +2,17 @@ package com.github.tartaricacid.touhoulittlemaid.event.food;
 
 import com.github.tartaricacid.touhoulittlemaid.api.event.MaidAfterEatEvent;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.CombinedInvWrapper;
+
+import java.util.List;
+
+import static com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig.MAID_EATEN_RETURN_CONTAINER_LIST;
 
 @Mod.EventBusSubscriber
 public class DefaultEatenEvent {
@@ -16,6 +21,17 @@ public class DefaultEatenEvent {
         ItemStack foodAfterEat = event.getFoodAfterEat();
         if (!foodAfterEat.isEmpty()) {
             ItemStack craftingRemainingItem = foodAfterEat.getCraftingRemainingItem();
+
+            if (craftingRemainingItem.isEmpty()) {
+                String itemId = ItemsUtil.getItemId(foodAfterEat.getItem());
+                for (List<String> strings : MAID_EATEN_RETURN_CONTAINER_LIST.get()) {
+                    if (strings.get(0).equals(itemId)) {
+                        craftingRemainingItem = ItemsUtil.getItemStack(strings.get(1));
+                        break;
+                    }
+                }
+            }
+
             if (!craftingRemainingItem.isEmpty()) {
                 EntityMaid maid = event.getMaid();
                 CombinedInvWrapper availableInv = maid.getAvailableInv(false);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/AbstractStoreMaidItem.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/AbstractStoreMaidItem.java
@@ -34,6 +34,9 @@ public abstract class AbstractStoreMaidItem extends Item {
 
     @Override
     public boolean onEntityItemUpdate(ItemStack stack, ItemEntity entity) {
+        if (!entity.isCurrentlyGlowing()) {
+            entity.setGlowingTag(true);
+        }
         if (!entity.isInvulnerable()) {
             entity.setInvulnerable(true);
         }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
@@ -3,11 +3,15 @@ package com.github.tartaricacid.touhoulittlemaid.util;
 import com.github.tartaricacid.touhoulittlemaid.api.bauble.IMaidBauble;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.BaubleItemHandler;
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -107,5 +111,25 @@ public final class ItemsUtil {
             }
         }
         return -1;
+    }
+
+    /**
+     * 获取物品Id
+     */
+    public static String getItemId(Item item) {
+        ResourceLocation key = ForgeRegistries.ITEMS.getKey(item);
+        Preconditions.checkNotNull(key);
+        return key.toString();
+    }
+
+
+    /**
+     * 获取物品
+     */
+    public static ItemStack getItemStack(String itemId) {
+        ResourceLocation resourceLocation = new ResourceLocation(itemId);
+        Item value = ForgeRegistries.ITEMS.getValue(resourceLocation);
+        Preconditions.checkNotNull(value);
+        return new ItemStack(value);
     }
 }

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.json
@@ -344,6 +344,8 @@
   "config.touhou_little_maid.maid.maid_home_meals_block_list_regex.desc": "These items cannot be used as a maid's home meals which match the regex, all words have to match",
   "config.touhou_little_maid.maid.maid_heal_meals_block_list_regex.name": "Maid Heal Meals Block List RegEx",
   "config.touhou_little_maid.maid.maid_heal_meals_block_list_regex.desc": "These items cannot be used as a maid's heal meals which match the regex, all words have to match",
+  "config.touhou_little_maid.maid.maid_eaten_return_container_list.name": "Maid Eaten Return Container List",
+  "config.touhou_little_maid.maid.maid_eaten_return_container_list.desc": "These entries configure the container returned after a maid has eaten \nEg: §eminecraft:beetroot_soup§c,§eminecraft:bowl",
   "config.touhou_little_maid.chair.chair_change_model.name": "Chair Change Model",
   "config.touhou_little_maid.chair.chair_change_model.desc": "Chair can switch models freely",
   "config.touhou_little_maid.chair.chair_can_destroyed_by_anyone.name": "Chair Can Destroyed by Anyone",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -344,6 +344,8 @@
   "config.touhou_little_maid.maid.maid_home_meals_block_list_regex.desc": "匹配的物品不能用于女仆的家庭餐，请使用正则全词匹配",
   "config.touhou_little_maid.maid.maid_heal_meals_block_list_regex.name": "女仆回血餐黑名单（正则匹配）",
   "config.touhou_little_maid.maid.maid_heal_meals_block_list_regex.desc": "匹配的物品不能用于女仆的回血餐，请使用正则全词匹配",
+  "config.touhou_little_maid.maid.maid_eaten_return_container_list.name": "女仆用餐后返回容器的列表",
+  "config.touhou_little_maid.maid.maid_eaten_return_container_list.desc": "这些条目配置了女仆用餐后要返回的容器\n例如: §eminecraft:beetroot_soup§c,§eminecraft:bowl",
   "config.touhou_little_maid.chair.chair_change_model.name": "坐垫能否切换模型",
   "config.touhou_little_maid.chair.chair_change_model.desc": "坐垫能否自由切换模型",
   "config.touhou_little_maid.chair.chair_can_destroyed_by_anyone.name": "坐垫可破坏",


### PR DESCRIPTION
- 像魂符这类重要物品，当以掉落物的形式存在时，赋予他们发光的效果，便于及时发现
- 尽管可以使用craftingRemaining获取容器，但还存在着不少模组食物并没有完善craftingRemaining，所以提供了个配置，但不知这个配置书写符不符合规范，酌情考虑吧...
- 当在REI界面浏览到模组物品时，大量的手办坐垫渲染使得游戏会卡顿，所以给他们折叠了起来，手办坐垫各渲染一个