### PR TITLE
emi和rei的兼容补全

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,11 +133,11 @@ dependencies {
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}"))
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}"))
     // at runtime, use the full JEI jar for Forge
-    compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
+    runtimeOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
 
     // rei
     implementation fg.deobf("curse.maven:architectury-api-419699:${architectury_api_id}")
-    implementation fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
+    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
 
     // emi
     // Forge (see below block as well if you use Forge Gradle)

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,10 @@ mixin {
 
 repositories {
     maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/"
+    }
+    maven {
         // location of the maven that hosts JEI files since January 2023
         // Patchouli
         name = "Jared's maven"
@@ -129,11 +133,16 @@ dependencies {
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}"))
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}"))
     // at runtime, use the full JEI jar for Forge
-    runtimeOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
+    compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
 
     // rei
-    runtimeOnly fg.deobf("curse.maven:architectury-api-419699:${architectury_api_id}")
-    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
+    implementation fg.deobf("curse.maven:architectury-api-419699:${architectury_api_id}")
+    implementation fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
+
+    // emi
+    // Forge (see below block as well if you use Forge Gradle)
+    compileOnly fg.deobf("dev.emi:emi-forge:${emi_version}:api")
+    compileOnly fg.deobf("dev.emi:emi-forge:${emi_version}")
 
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ enchantment_descriptions_id=5136988
 tacz_version=1.0.0-beta
 architectury_api_id=5137938
 rei_version=12.1.725
+emi_version=1.1.6+1.20.1

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
@@ -495,20 +495,12 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
         }
     }
 
-    @Override
-    public int getGuiLeft() {
-        if (taskListOpen) {
-            return leftPos - 93;
-        }
-        return leftPos;
+    public boolean isTaskListOpen() {
+        return taskListOpen;
     }
 
-    @Override
-    public int getXSize() {
-        if (taskListOpen) {
-            return imageWidth + 93;
-        }
-        return imageWidth;
+    public int[] getTaskListAreas() {
+        return new int[] { leftPos - 93, topPos + 5, 92, 251 };
     }
 
     public EntityMaid getMaid() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/MaidEmiPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/MaidEmiPlugin.java
@@ -1,0 +1,67 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.emi;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.emi.altar.EmiAltarRecipeCategory;
+import com.github.tartaricacid.touhoulittlemaid.compat.emi.altar.EmiAltarRecipeMaker;
+import com.github.tartaricacid.touhoulittlemaid.compat.emi.transfer.BackpackRecipeHandler;
+import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.backpack.CraftingTableBackpackContainer;
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.backpack.FurnaceBackpackContainer;
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@EmiEntrypoint
+public class MaidEmiPlugin implements EmiPlugin {
+    public static final EmiRecipeCategory ALTAR = new EmiAltarRecipeCategory();
+
+    private static void registerAltarRecipeCategory(EmiRegistry registry) {
+        registry.addCategory(ALTAR);
+        registry.addWorkstation(ALTAR, EmiStack.of(InitItems.HAKUREI_GOHEI.get()));
+        registry.addWorkstation(ALTAR, EmiStack.of(InitItems.SANAE_GOHEI.get()));
+
+        EmiAltarRecipeMaker.registerAltarRecipes(registry);
+    }
+
+    // 用来隐藏过多的手办和坐垫
+    private static void hideStacks(EmiRegistry registry) {
+        List<ItemStack> groupItems = new ArrayList<>();
+        groupItems.add(InitItems.GARAGE_KIT.get().getDefaultInstance());
+        groupItems.add(InitItems.CHAIR.get().getDefaultInstance());
+
+        // 先干掉所有手办和坐垫
+        registry.removeEmiStacks(emiStack -> {
+            ItemStack itemStack = emiStack.getItemStack();
+            for (ItemStack groupItem : groupItems) {
+                if (itemStack.is(groupItem.getItem()) && !ItemStack.matches(groupItem, itemStack)) {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // 再各自添加一个回去
+        for (ItemStack item : groupItems) {
+            registry.addEmiStackAfter(EmiStack.of(item), emiStack -> emiStack.getItemStack().is(InitItems.POWER_POINT.get()));
+        }
+    }
+
+    private static void registerRecipeHandlers(EmiRegistry registry) {
+        registry.addRecipeHandler(CraftingTableBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.CRAFTING, 71, 9, 0, 70));
+        registry.addRecipeHandler(FurnaceBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.SMELTING, 70, 1, 0, 70));
+        registry.addRecipeHandler(FurnaceBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.FUEL, 71, 1, 0, 70));
+    }
+
+    @Override
+    public void register(EmiRegistry registry) {
+        registerAltarRecipeCategory(registry);
+        registerRecipeHandlers(registry);
+        hideStacks(registry);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/MaidEmiPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/MaidEmiPlugin.java
@@ -1,5 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.emi;
 
+import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.AbstractMaidContainerGui;
 import com.github.tartaricacid.touhoulittlemaid.compat.emi.altar.EmiAltarRecipeCategory;
 import com.github.tartaricacid.touhoulittlemaid.compat.emi.altar.EmiAltarRecipeMaker;
 import com.github.tartaricacid.touhoulittlemaid.compat.emi.transfer.BackpackRecipeHandler;
@@ -12,6 +13,7 @@ import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.Bounds;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
@@ -21,7 +23,7 @@ import java.util.List;
 public class MaidEmiPlugin implements EmiPlugin {
     public static final EmiRecipeCategory ALTAR = new EmiAltarRecipeCategory();
 
-    private static void registerAltarRecipeCategory(EmiRegistry registry) {
+    private void registerAltarRecipeCategory(EmiRegistry registry) {
         registry.addCategory(ALTAR);
         registry.addWorkstation(ALTAR, EmiStack.of(InitItems.HAKUREI_GOHEI.get()));
         registry.addWorkstation(ALTAR, EmiStack.of(InitItems.SANAE_GOHEI.get()));
@@ -30,7 +32,7 @@ public class MaidEmiPlugin implements EmiPlugin {
     }
 
     // 用来隐藏过多的手办和坐垫
-    private static void hideStacks(EmiRegistry registry) {
+    private void hideStacks(EmiRegistry registry) {
         List<ItemStack> groupItems = new ArrayList<>();
         groupItems.add(InitItems.GARAGE_KIT.get().getDefaultInstance());
         groupItems.add(InitItems.CHAIR.get().getDefaultInstance());
@@ -52,16 +54,28 @@ public class MaidEmiPlugin implements EmiPlugin {
         }
     }
 
-    private static void registerRecipeHandlers(EmiRegistry registry) {
+    private void registerRecipeHandlers(EmiRegistry registry) {
         registry.addRecipeHandler(CraftingTableBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.CRAFTING, 71, 9, 0, 70));
         registry.addRecipeHandler(FurnaceBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.SMELTING, 70, 1, 0, 70));
         registry.addRecipeHandler(FurnaceBackpackContainer.TYPE, new BackpackRecipeHandler<>(VanillaEmiRecipeCategories.FUEL, 71, 1, 0, 70));
+    }
+
+    private void registerExclusionArea(EmiRegistry registry) {
+        registry.addGenericExclusionArea(((screen, consumer) -> {
+            if (!(screen instanceof AbstractMaidContainerGui<?> maidContainerGui)) return;
+
+            if (maidContainerGui.isTaskListOpen()) {
+                int[] taskListAreas = maidContainerGui.getTaskListAreas();
+                consumer.accept(new Bounds(taskListAreas[0], taskListAreas[1], taskListAreas[2], taskListAreas[3]));
+            }
+        }));
     }
 
     @Override
     public void register(EmiRegistry registry) {
         registerAltarRecipeCategory(registry);
         registerRecipeHandlers(registry);
+        registerExclusionArea(registry);
         hideStacks(registry);
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipe.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipe.java
@@ -1,0 +1,95 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.emi.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.compat.emi.MaidEmiPlugin;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class EmiAltarRecipe implements EmiRecipe {
+    private static final EmiTexture POWER_ICON = new EmiTexture(new ResourceLocation(TouhouLittleMaid.MOD_ID, "textures/entity/power_point.png"), 32, 0, 16, 16, 16, 16, 64, 64);
+    private final ResourceLocation id;
+    private final List<EmiStack> outputs;
+    private final List<EmiIngredient> inputs;
+    private final float powerCost;
+    private final String langKey;
+
+    public EmiAltarRecipe(ResourceLocation id, List<EmiIngredient> inputs, List<EmiStack> outputs, float powerCost, String langKey) {
+        this.id = id;
+        this.inputs = inputs;
+        this.outputs = outputs;
+        this.powerCost = powerCost;
+        this.langKey = langKey;
+    }
+    @Override
+    public EmiRecipeCategory getCategory() {
+        return MaidEmiPlugin.ALTAR;
+    }
+
+    @Override
+    public @Nullable ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public List<EmiIngredient> getInputs() {
+        return inputs;
+    }
+
+    @Override
+    public List<EmiStack> getOutputs() {
+        return outputs;
+    }
+
+    @Override
+    public int getDisplayWidth() {
+        return 160;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 125;
+    }
+
+    @Override
+    public boolean supportsRecipeTree() {
+        return true;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        int darkGray = 0x555555;
+        Font font = Minecraft.getInstance().font;
+        String result = I18n.get("jei.touhou_little_maid.altar_craft.result", I18n.get(this.langKey));
+
+        widgets.addSlot(getInput(inputs, 0), 40, 35);
+        widgets.addSlot(getInput(inputs, 1), 40, 55);
+        widgets.addSlot(getInput(inputs, 2), 60, 15);
+        widgets.addSlot(getInput(inputs, 3), 80, 15);
+        widgets.addSlot(getInput(inputs, 4), 100, 35);
+        widgets.addSlot(getInput(inputs, 5), 100, 55);
+        widgets.addSlot(outputs.get(0), 140, 5);
+
+        widgets.addTexture(POWER_ICON, 72, 38);
+        widgets.addText(Component.literal(result), (int) ((widgets.getWidth() - font.width(result)) / 2.0f), 85, darkGray, false);
+        widgets.addText(Component.literal(String.format("×%.2f", powerCost)), 65, 55, darkGray, false);
+    }
+
+    private EmiIngredient getInput(List<EmiIngredient> inputs, int index) {
+        if (index < inputs.size()) {
+            return inputs.get(index);
+        }
+        return EmiStack.EMPTY;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipeCategory.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipeCategory.java
@@ -1,0 +1,27 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.emi.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+
+// 用来渲染祭坛图标
+public class EmiAltarRecipeCategory extends EmiRecipeCategory {
+
+    public static final ResourceLocation ID = new ResourceLocation(TouhouLittleMaid.MOD_ID, "altar");
+    private static final ResourceLocation ALTAR_ICON = new ResourceLocation(TouhouLittleMaid.MOD_ID, "textures/gui/altar_icon.png");
+
+    public EmiAltarRecipeCategory() {
+        super(ID, (draw, x, y, delta) -> {});
+    }
+
+    @Override
+    public void render(GuiGraphics draw, int x, int y, float delta) {
+        draw.blit(ALTAR_ICON, x, y, 0, 0, 16, 16, 16, 16);
+    }
+
+    @Override
+    public void renderSimplified(GuiGraphics draw, int x, int y, float delta) {
+        draw.blit(ALTAR_ICON, x, y, 0, 0, 16, 16, 16, 16);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipeMaker.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/altar/EmiAltarRecipeMaker.java
@@ -1,0 +1,27 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.emi.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.crafting.AltarRecipe;
+import com.github.tartaricacid.touhoulittlemaid.init.InitRecipes;
+import com.github.tartaricacid.touhoulittlemaid.util.JERIUtil;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+
+import java.util.List;
+
+public final class EmiAltarRecipeMaker {
+
+    public static void registerAltarRecipes(EmiRegistry registry){
+        List<AltarRecipe> allRecipesFor = registry.getRecipeManager().getAllRecipesFor(InitRecipes.ALTAR_CRAFTING);
+        JERIUtil.recipeWarp(allRecipesFor, (recipeId, inputs, output, powerCost, langKey) -> {
+            List<EmiIngredient> inputs1 = inputs.stream()
+                    .filter(it -> !it.isEmpty())
+                    .map(EmiIngredient::of)
+                    .toList();
+            List<EmiStack> outputs = List.of(EmiStack.of(output));
+
+            registry.addRecipe(new EmiAltarRecipe(recipeId, inputs1, outputs, powerCost, langKey));
+        });
+    }
+
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/transfer/BackpackRecipeHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/emi/transfer/BackpackRecipeHandler.java
@@ -1,0 +1,62 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.emi.transfer;
+
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.MaidMainContainer;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.recipe.handler.StandardRecipeHandler;
+import net.minecraft.world.inventory.Slot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BackpackRecipeHandler<C extends MaidMainContainer> implements StandardRecipeHandler<C> {
+    private final EmiRecipeCategory recipeCategory;
+    private final int recipeSlotStart;
+    private final int recipeSlotCount;
+    private final int inventorySlotStart;
+    private final int inventorySlotCount;
+
+    public BackpackRecipeHandler(EmiRecipeCategory categoryIdentifier, int recipeSlotStart, int recipeSlotCount, int inventorySlotStart, int inventorySlotCount) {
+        this.recipeCategory = categoryIdentifier;
+        this.recipeSlotStart = recipeSlotStart;
+        this.recipeSlotCount = recipeSlotCount;
+        this.inventorySlotStart = inventorySlotStart;
+        this.inventorySlotCount = inventorySlotCount;
+    }
+
+    /**
+     * @param handler
+     * @return The slots for the recipe handler to source ingredients from.
+     * Typically this should include the player's inventory, and crafting slots.
+     */
+    @Override
+    public List<Slot> getInputSources(C handler) {
+        List<Slot> slots = new ArrayList<>();
+        for (int i = inventorySlotStart; i < inventorySlotStart + inventorySlotCount; i++) {
+            slots.add(handler.getSlot(i));
+        }
+        return slots;
+    }
+
+    /**
+     * @param handler
+     * @return The slots where inputs should be placed to perform crafting.
+     */
+    @Override
+    public List<Slot> getCraftingSlots(C handler) {
+        List<Slot> slots = new ArrayList<>();
+        for (int i = recipeSlotStart; i < recipeSlotStart + recipeSlotCount; i++) {
+            slots.add(handler.getSlot(i));
+        }
+        return slots;
+    }
+
+    /**
+     * @param recipe
+     * @return Whether the handler is applicable for the provided recipe.
+     */
+    @Override
+    public boolean supportsRecipe(EmiRecipe recipe) {
+        return recipe.getCategory() == recipeCategory;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/MaidPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/MaidPlugin.java
@@ -1,6 +1,7 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.jei;
 
 import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.AbstractMaidContainerGui;
 import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.CraftingTableBackpackContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.FurnaceBackpackContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.compat.jei.altar.AltarRecipeCategory;
@@ -13,9 +14,14 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.RecipeTypes;
 import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.handlers.IGuiContainerHandler;
 import mezz.jei.api.registration.*;
+import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collections;
+import java.util.List;
 
 @JeiPlugin
 public class MaidPlugin implements IModPlugin {
@@ -53,6 +59,20 @@ public class MaidPlugin implements IModPlugin {
     public void registerGuiHandlers(IGuiHandlerRegistration registration) {
         registration.addRecipeClickArea(CraftingTableBackpackContainerScreen.class, 213, 121, 13, 12, RecipeTypes.CRAFTING);
         registration.addRecipeClickArea(FurnaceBackpackContainerScreen.class, 183, 118, 28, 24, RecipeTypes.SMELTING, RecipeTypes.FUELING);
+        registerTaskListArea(registration);
+    }
+
+    private void registerTaskListArea(IGuiHandlerRegistration registration){
+        registration.addGenericGuiContainerHandler(AbstractMaidContainerGui.class, new IGuiContainerHandler<AbstractMaidContainerGui<?>>() {
+            @Override
+            public List<Rect2i> getGuiExtraAreas(AbstractMaidContainerGui containerScreen) {
+                if (containerScreen.isTaskListOpen()){
+                    int[] taskListAreas = containerScreen.getTaskListAreas();
+                    return Collections.singletonList(new Rect2i(taskListAreas[0], taskListAreas[1], taskListAreas[2], taskListAreas[3]));
+                }
+                return Collections.emptyList();
+            }
+        });
     }
 
     @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/altar/AltarRecipeMaker.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/altar/AltarRecipeMaker.java
@@ -1,20 +1,15 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.jei.altar;
 
 import com.github.tartaricacid.touhoulittlemaid.crafting.AltarRecipe;
-import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
 import com.github.tartaricacid.touhoulittlemaid.init.InitRecipes;
-import com.github.tartaricacid.touhoulittlemaid.item.ItemEntityPlaceholder;
+import com.github.tartaricacid.touhoulittlemaid.util.JERIUtil;
 import com.google.common.collect.Lists;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeManager;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
 public final class AltarRecipeMaker {
@@ -31,24 +26,16 @@ public final class AltarRecipeMaker {
 
     public List<AltarRecipeWrapper> getAltarRecipes() {
         List<AltarRecipe> altarRecipesMap = recipeManager.getAllRecipesFor(InitRecipes.ALTAR_CRAFTING);
+
         List<AltarRecipeWrapper> recipes = Lists.newArrayList();
-        for (AltarRecipe recipe : altarRecipesMap) {
-            ResourceLocation recipeId = recipe.getId();
-            ItemStack output = recipe.getResultItem(Minecraft.getInstance().level.registryAccess());
-            if (!recipe.isItemCraft()) {
-                output = InitItems.ENTITY_PLACEHOLDER.get().getDefaultInstance();
-                ItemEntityPlaceholder.setRecipeId(output, recipe.getId());
-            }
-            String namespace = recipeId.getNamespace().toLowerCase(Locale.US);
-            String langKey;
-            if (recipe.isItemCraft()) {
-                langKey = String.format("jei.%s.altar_craft.%s.result", namespace, "item_craft");
-            } else {
-                Path path = Paths.get(recipeId.getPath().toLowerCase(Locale.US));
-                langKey = String.format("jei.%s.altar_craft.%s.result", namespace, path.getFileName());
-            }
-            recipes.add(new AltarRecipeWrapper(recipe.getIngredients(), output, recipe.getPowerCost(), langKey));
-        }
+        JERIUtil.recipeWarp(altarRecipesMap, (recipeId, inputs, output, powerCost, langKey) -> {
+            List<List<ItemStack>> inputs1 = inputs.stream()
+                    .filter(ingredient -> !ingredient.isEmpty())
+                    .map(ingredient -> List.of(ingredient.getItems()))
+                    .toList();
+            recipes.add(new AltarRecipeWrapper(inputs1, output, powerCost, langKey));
+        });
+
         return recipes;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/altar/AltarRecipeWrapper.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/jei/altar/AltarRecipeWrapper.java
@@ -1,8 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.jei.altar;
 
-import com.google.common.collect.Lists;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 
 import java.util.List;
 
@@ -12,14 +10,9 @@ public class AltarRecipeWrapper {
     private final float powerCost;
     private final String langKey;
 
-    AltarRecipeWrapper(List<Ingredient> inputs, ItemStack output, float powerCost, String langKey) {
-        this.inputs = Lists.newArrayList();
+    AltarRecipeWrapper(List<List<ItemStack>> inputs, ItemStack output, float powerCost, String langKey) {
+        this.inputs = inputs;
         this.output = output;
-        for (Ingredient input : inputs) {
-            if (!input.isEmpty()) {
-                this.inputs.add(Lists.newArrayList(input.getItems()));
-            }
-        }
         this.powerCost = powerCost;
         this.langKey = langKey;
     }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
@@ -1,10 +1,28 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.rei;
 
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.CraftingTableBackpackContainerScreen;
+import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.FurnaceBackpackContainerScreen;
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.altar.ReiAltarRecipeCategory;
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.altar.ReiAltarRecipeDisplay;
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.altar.ReiAltarRecipeMaker;
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.transfer.BackpackTransferHandler;
 import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.backpack.CraftingTableBackpackContainer;
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.backpack.FurnaceBackpackContainer;
+import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.entry.CollapsibleEntryRegistry;
+import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
+import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes;
+import me.shedaniel.rei.api.common.util.EntryStacks;
 import me.shedaniel.rei.forge.REIPluginClient;
+import me.shedaniel.rei.plugin.common.BuiltinPlugin;
+import me.shedaniel.rei.plugin.common.displays.DefaultInformationDisplay;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -15,13 +33,15 @@ import java.util.List;
 @REIPluginClient
 public class MaidREIClientPlugin implements REIClientPlugin {
 
+    public static final CategoryIdentifier<ReiAltarRecipeDisplay> ALTAR = CategoryIdentifier.of(TouhouLittleMaid.MOD_ID, "plugin/altar");
+
     /**
      * Registers entries to collapse on the entry panel.
      *
      * @param registry the collapsible entry registry
      */
-    @SuppressWarnings("UnstableApiUsage")
     @Override
+    @SuppressWarnings("UnstableApiUsage")
     public void registerCollapsibleEntries(CollapsibleEntryRegistry registry) {
         List<Item> groupItems = new ArrayList<>();
         groupItems.add(InitItems.GARAGE_KIT.get());
@@ -30,5 +50,50 @@ public class MaidREIClientPlugin implements REIClientPlugin {
             ResourceLocation groupId = ForgeRegistries.ITEMS.getKey(item);
             registry.group(groupId, item.getDescription(), VanillaEntryTypes.ITEM, (entryStack) -> entryStack.getValue().is(item));
         }
+    }
+
+    /**
+     * Registers new categories
+     *
+     * @param registry the category registry
+     */
+    @Override
+    public void registerCategories(CategoryRegistry registry) {
+        registry.add(new ReiAltarRecipeCategory());
+
+        registry.addWorkstations(ALTAR, EntryStacks.of(InitItems.SANAE_GOHEI.get()), EntryStacks.of(InitItems.HAKUREI_GOHEI.get()));
+    }
+
+    /**
+     * Registers new displays for categories
+     *
+     * @param registry the display registry
+     */
+    @Override
+    public void registerDisplays(DisplayRegistry registry) {
+        ReiAltarRecipeMaker.registerAltarRecipes(registry);
+    }
+
+    /**
+     * Registers screen deciders
+     *
+     * @param registry the screen registry
+     */
+    @Override
+    public void registerScreens(ScreenRegistry registry) {
+        registry.registerContainerClickArea(new Rectangle(213, 121, 13, 12), CraftingTableBackpackContainerScreen.class, BuiltinPlugin.CRAFTING);
+        registry.registerContainerClickArea(new Rectangle(183, 118, 28, 24), FurnaceBackpackContainerScreen.class, BuiltinPlugin.SMELTING, BuiltinPlugin.FUEL);
+    }
+
+    /**
+     * Registers new transfer handlers
+     *
+     * @param registry the registry
+     */
+    @Override
+    public void registerTransferHandlers(TransferHandlerRegistry registry) {
+        registry.register(new BackpackTransferHandler(CraftingTableBackpackContainer.class, BuiltinPlugin.CRAFTING, 71, 9, 0, 70));
+        registry.register(new BackpackTransferHandler(FurnaceBackpackContainer.class, BuiltinPlugin.SMELTING, 70, 1, 0, 70));
+        registry.register(new BackpackTransferHandler(FurnaceBackpackContainer.class, BuiltinPlugin.FUEL, 71, 1, 0, 70));
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/MaidREIClientPlugin.java
@@ -1,6 +1,7 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.rei;
 
 import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.AbstractMaidContainerGui;
 import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.CraftingTableBackpackContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.backpack.FurnaceBackpackContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.compat.rei.altar.ReiAltarRecipeCategory;
@@ -15,6 +16,8 @@ import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
 import me.shedaniel.rei.api.client.registry.entry.CollapsibleEntryRegistry;
+import me.shedaniel.rei.api.client.registry.screen.ExclusionZones;
+import me.shedaniel.rei.api.client.registry.screen.ExclusionZonesProvider;
 import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
 import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
@@ -28,6 +31,8 @@ import net.minecraft.world.item.Item;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 @REIPluginClient
@@ -95,5 +100,24 @@ public class MaidREIClientPlugin implements REIClientPlugin {
         registry.register(new BackpackTransferHandler(CraftingTableBackpackContainer.class, BuiltinPlugin.CRAFTING, 71, 9, 0, 70));
         registry.register(new BackpackTransferHandler(FurnaceBackpackContainer.class, BuiltinPlugin.SMELTING, 70, 1, 0, 70));
         registry.register(new BackpackTransferHandler(FurnaceBackpackContainer.class, BuiltinPlugin.FUEL, 71, 1, 0, 70));
+    }
+
+    /**
+     * Registers screen exclusion zones
+     *
+     * @param zones the exclusion zones registry
+     */
+    @Override
+    public void registerExclusionZones(ExclusionZones zones) {
+        zones.register(AbstractMaidContainerGui.class, new ExclusionZonesProvider<AbstractMaidContainerGui<?>>() {
+            @Override
+            public Collection<Rectangle> provide(AbstractMaidContainerGui screen) {
+                if (screen.isTaskListOpen()){
+                    int[] taskListAreas = screen.getTaskListAreas();
+                    return Collections.singletonList(new Rectangle(taskListAreas[0], taskListAreas[1], taskListAreas[2], taskListAreas[3]));
+                }
+                return Collections.emptyList();
+            }
+        });
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeCategory.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeCategory.java
@@ -1,0 +1,133 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.rei.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.MaidREIClientPlugin;
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.entry.EntryStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReiAltarRecipeCategory implements DisplayCategory<ReiAltarRecipeDisplay> {
+    private static final MutableComponent TITLE = Component.translatable("jei.touhou_little_maid.altar_craft.title");
+    private static final ResourceLocation ALTAR_ICON = new ResourceLocation(TouhouLittleMaid.MOD_ID, "textures/gui/altar_icon.png");
+    private static final ResourceLocation POWER_ICON = new ResourceLocation(TouhouLittleMaid.MOD_ID, "textures/entity/power_point.png");
+    private final Renderer icon;
+
+    public ReiAltarRecipeCategory() {
+        icon = (graphics, bounds, mouseX, mouseY, delta) -> graphics.blit(ALTAR_ICON, bounds.x, bounds.y, 0, 0, 16, 16, 16, 16);
+    }
+
+    /**
+     * Returns the identifier of this {@link DisplayCategory}.
+     * This identifier must be the same one used to register the category
+     * in {@link CategoryRegistry}.
+     *
+     * @return the identifier of this category
+     */
+    @Override
+    public CategoryIdentifier<? extends ReiAltarRecipeDisplay> getCategoryIdentifier() {
+        return MaidREIClientPlugin.ALTAR;
+    }
+
+    /**
+     * Returns the category title for the category.
+     *
+     * @return the title
+     */
+    @Override
+    public Component getTitle() {
+        return TITLE;
+    }
+
+    /**
+     * Returns the renderer of the icon displayed in the category tab.
+     * <p>
+     * A simple implementation is the {@link EntryStack}.
+     *
+     * @return the renderer of the icon
+     */
+    @Override
+    public Renderer getIcon() {
+        return icon;
+    }
+
+    /**
+     * Returns the display height, the display height is consistent between all displays in the category.
+     *
+     * @return the display height
+     */
+    @Override
+    public int getDisplayHeight() {
+        return 125;
+    }
+
+    /**
+     * Returns the display width, the display width can be display-dependent.
+     *
+     * @param display the display
+     * @return the display width
+     */
+    @Override
+    public int getDisplayWidth(ReiAltarRecipeDisplay display) {
+        return 160;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param display
+     * @param bounds
+     */
+    @Override
+    public List<Widget> setupDisplay(ReiAltarRecipeDisplay display, Rectangle bounds) {
+        int darkGray = 0x555555;
+        Font font = Minecraft.getInstance().font;
+        String result = I18n.get("jei.touhou_little_maid.altar_craft.result", I18n.get(display.getLangKey()));
+        int startX = bounds.x;
+        int startY = bounds.y + 5;
+
+        List<Widget> widgets = new ArrayList<>();
+        widgets.add(Widgets.createRecipeBase(bounds));
+        widgets.add(Widgets.createSlot(new Point(startX + 40, startY + 35)).entries(getInput(display.getInputEntries(), 0)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 40, startY + 55)).entries(getInput(display.getInputEntries(), 1)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 60, startY + 15)).entries(getInput(display.getInputEntries(), 2)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 80, startY + 15)).entries(getInput(display.getInputEntries(), 3)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 100, startY + 35)).entries(getInput(display.getInputEntries(), 4)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 100, startY + 55)).entries(getInput(display.getInputEntries(), 5)).markInput());
+        widgets.add(Widgets.createSlot(new Point(startX + 140 - 5, startY + 5)).entries(display.getOutputEntries().get(0)).markOutput());
+
+
+        widgets.add(Widgets.createTexturedWidget(POWER_ICON, startX + 72, startY + 38, 32, 0, 16, 16, 64, 64));
+        widgets.add(Widgets.withTranslate(Widgets.createDrawableWidget((guiGraphics, mouseX, mouseY, v) -> {
+            guiGraphics.drawString(font, result, 0, 0, darkGray, false);
+        }), startX + (int) ((bounds.getWidth() - font.width(result)) / 2.0f), startY + 85, 0));
+
+        widgets.add(Widgets.withTranslate(Widgets.createDrawableWidget((guiGraphics, mouseX, mouseY, v) -> {
+            guiGraphics.drawString(font, String.format("×%.2f", display.getPowerCost()), 0, 0, darkGray, false);
+        }), startX + 65, startY + 55, 0));
+
+        return widgets;
+    }
+
+    private EntryIngredient getInput(List<EntryIngredient> inputs, int index) {
+        if (index < inputs.size()) {
+            return inputs.get(index);
+        }
+        return EntryIngredient.empty();
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeDisplay.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeDisplay.java
@@ -1,0 +1,80 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.rei.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.rei.MaidREIClientPlugin;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ReiAltarRecipeDisplay implements Display {
+    private final ResourceLocation id;
+    private final List<EntryIngredient> inputs;
+    private final List<EntryIngredient> outputs;
+    private final float powerCost;
+    private final String langKey;
+
+    public ReiAltarRecipeDisplay(ResourceLocation id, List<EntryIngredient> inputs, List<EntryIngredient> outputs, float powerCost, String langKey) {
+        this.id = id;
+        this.inputs = inputs;
+        this.outputs = outputs;
+        this.powerCost = powerCost;
+        this.langKey = langKey;
+    }
+
+    /**
+     * Returns the list of inputs for this display. This only affects the stacks resolving for the display,
+     * and not necessarily the stacks that are displayed.
+     *
+     * @return a list of inputs
+     */
+    @Override
+    public List<EntryIngredient> getInputEntries() {
+        return inputs;
+    }
+
+    /**
+     * Returns the list of outputs for this display. This only affects the stacks resolving for the display,
+     * and not necessarily the stacks that are displayed.
+     *
+     * @return a list of outputs
+     */
+    @Override
+    public List<EntryIngredient> getOutputEntries() {
+        return outputs;
+    }
+
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    public float getPowerCost() {
+        return powerCost;
+    }
+
+    public String getLangKey() {
+        return langKey;
+    }
+
+    /**
+     * Returns the identifier of the category this display belongs to.
+     *
+     * @return the identifier of the category
+     */
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return MaidREIClientPlugin.ALTAR;
+    }
+
+    /**
+     * Returns the display location from data packs.
+     *
+     * @return the display location
+     */
+    @Override
+    public Optional<ResourceLocation> getDisplayLocation() {
+        return Optional.of(id);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeMaker.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/altar/ReiAltarRecipeMaker.java
@@ -1,0 +1,31 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.rei.altar;
+
+import com.github.tartaricacid.touhoulittlemaid.crafting.AltarRecipe;
+import com.github.tartaricacid.touhoulittlemaid.init.InitRecipes;
+import com.github.tartaricacid.touhoulittlemaid.util.JERIUtil;
+import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class ReiAltarRecipeMaker{
+
+    public static void registerAltarRecipes(DisplayRegistry registry) {
+        List<AltarRecipe> allRecipesFor = registry.getRecipeManager().getAllRecipesFor(InitRecipes.ALTAR_CRAFTING);
+
+        JERIUtil.recipeWarp(allRecipesFor, ((recipeId, inputs, output, powerCost, langKey) -> {
+            List<EntryIngredient> inputs1 = inputs.stream()
+                    .filter(it -> !it.isEmpty())
+                    .map(ingredient -> {
+                        return EntryIngredient.of(Arrays.stream(ingredient.getItems()).map(EntryStacks::of).toList());
+                    })
+                    .toList();
+
+            List<EntryIngredient> outputs = List.of(EntryIngredient.of(EntryStacks.of(output)));
+            registry.add(new ReiAltarRecipeDisplay(recipeId, inputs1, outputs, powerCost, langKey));
+        }));
+    }
+
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/transfer/BackpackTransferHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/rei/transfer/BackpackTransferHandler.java
@@ -1,0 +1,57 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.rei.transfer;
+
+import com.github.tartaricacid.touhoulittlemaid.inventory.container.MaidMainContainer;
+import me.shedaniel.rei.api.client.registry.transfer.simple.SimpleTransferHandler;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.transfer.info.stack.SlotAccessor;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@SuppressWarnings("UnstableApiUsage")
+public class BackpackTransferHandler implements SimpleTransferHandler {
+    private final Class<? extends MaidMainContainer> containerClass;
+    private final CategoryIdentifier<?> categoryIdentifier;
+    private final int recipeSlotStart;
+    private final int recipeSlotCount;
+    private final int inventorySlotStart;
+    private final int inventorySlotCount;
+
+
+    public BackpackTransferHandler(Class<? extends MaidMainContainer> containerClass, CategoryIdentifier<?> categoryIdentifier, int recipeSlotStart, int recipeSlotCount, int inventorySlotStart, int inventorySlotCount) {
+        this.containerClass = containerClass;
+        this.categoryIdentifier = categoryIdentifier;
+        this.recipeSlotStart = recipeSlotStart;
+        this.recipeSlotCount = recipeSlotCount;
+        this.inventorySlotStart = inventorySlotStart;
+        this.inventorySlotCount = inventorySlotCount;
+    }
+
+
+    @Override
+    public ApplicabilityResult checkApplicable(Context context) {
+        if (!containerClass.isInstance(context.getMenu())
+                || !categoryIdentifier.equals(context.getDisplay().getCategoryIdentifier())
+                || context.getContainerScreen() == null) {
+            return ApplicabilityResult.createNotApplicable();
+        } else {
+            return ApplicabilityResult.createApplicable();
+        }
+    }
+
+    @Override
+    public Iterable<SlotAccessor> getInputSlots(Context context) {
+        return IntStream.range(recipeSlotStart, recipeSlotStart + recipeSlotCount)
+                .mapToObj(id -> SlotAccessor.fromSlot(context.getMenu().getSlot(id)))
+                .toList();
+    }
+
+    @Override
+    public Iterable<SlotAccessor> getInventorySlots(Context context) {
+        AbstractContainerMenu menu = context.getMenu();
+        return IntStream.range(inventorySlotStart, inventorySlotCount)
+                .mapToObj(index -> SlotAccessor.fromSlot(menu.getSlot(index)))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/JERIUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/JERIUtil.java
@@ -1,0 +1,45 @@
+package com.github.tartaricacid.touhoulittlemaid.util;
+
+import com.github.tartaricacid.touhoulittlemaid.crafting.AltarRecipe;
+import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
+import com.github.tartaricacid.touhoulittlemaid.item.ItemEntityPlaceholder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+
+public final class JERIUtil {
+
+    public static void recipeWarp(List<AltarRecipe> altarRecipes, AltarRecipeMaker maker) {
+        for (AltarRecipe altarRecipe : altarRecipes) {
+            ResourceLocation recipeId = altarRecipe.getId();
+            ItemStack output = altarRecipe.getResultItem(Minecraft.getInstance().level.registryAccess());
+            if (!altarRecipe.isItemCraft()) {
+                output = InitItems.ENTITY_PLACEHOLDER.get().getDefaultInstance();
+                ItemEntityPlaceholder.setRecipeId(output, altarRecipe.getId());
+            }
+            String namespace = recipeId.getNamespace().toLowerCase(Locale.US);
+            String langKey;
+            if (altarRecipe.isItemCraft()) {
+                langKey = String.format("jei.%s.altar_craft.%s.result", namespace, "item_craft");
+            } else {
+                Path path = Paths.get(recipeId.getPath().toLowerCase(Locale.US));
+                langKey = String.format("jei.%s.altar_craft.%s.result", namespace, path.getFileName());
+            }
+
+            maker.accept(recipeId, altarRecipe.getIngredients(), output, altarRecipe.getPowerCost(), langKey);
+        }
+    }
+
+    public interface AltarRecipeMaker {
+        void accept(ResourceLocation recipeId, NonNullList<Ingredient> inputs, ItemStack output, float powerCost, String langKey);
+
+    }
+
+}

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.json
@@ -504,6 +504,7 @@
   "subtitle.touhou_little_maid.block.gomoku_reset": "Gomoku Reset Sound",
   "subtitle.touhou_little_maid.entity.box": "Box Open Sound",
   "subtitle.touhou_little_maid.item.compass": "Compass Select Point Sound",
+  "emi.category.touhou_little_maid.altar": "Altar Craft",
   "jei.touhou_little_maid.altar_craft.title": "Altar Craft",
   "jei.touhou_little_maid.altar_craft.result": "Result: %s",
   "jei.touhou_little_maid.altar_craft.item_craft.result": "Craft an Item",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -504,6 +504,7 @@
   "subtitle.touhou_little_maid.block.gomoku_reset": "五子棋：重置",
   "subtitle.touhou_little_maid.entity.box": "盒子：打开",
   "subtitle.touhou_little_maid.item.compass": "罗盘：选择点",
+  "emi.category.touhou_little_maid.altar": "祭坛合成",
   "jei.touhou_little_maid.altar_craft.title": "祭坛合成",
   "jei.touhou_little_maid.altar_craft.result": "结果：%s",
   "jei.touhou_little_maid.altar_craft.item_craft.result": "合成物品",


### PR DESCRIPTION
- 原生支持REI查看祭坛配方合成
- 支持工作台、熔炉背包的快速合成和查看
- 原生支持EMI查看级配配方合成
- 支持工作台、熔炉背包的快速合成（EMI自身没有便捷查看，就没做这个）
- 隐藏过多的手办和坐垫
- 以及[#526](https://github.com/TartaricAcid/TouhouLittleMaid/issues/526)所说的EMI页面显示问题，顺带也对REI做出了同样处理

原本还想添加手办的那个信息来着，但奈何工作区出了问题...就没加上去了....
（虽说也没多大的作用就是了...除了emi隐藏那个...