### PR TITLE
修复关闭已不存在的女仆的背包导致的崩溃

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/container/AbstractMaidContainer.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/container/AbstractMaidContainer.java
@@ -39,7 +39,9 @@ public abstract class AbstractMaidContainer extends AbstractContainerMenu {
     @Override
     public void removed(Player playerIn) {
         super.removed(playerIn);
-        maid.guiOpening = false;
+        if (maid != null) {
+            maid.guiOpening = false;
+        }
     }
 
     @Override


### PR DESCRIPTION
修复下面的偶发崩溃：
```
java.lang.NullPointerException: Cannot assign field "guiOpening" because "this.maid" is null
    at com.github.tartaricacid.touhoulittlemaid.inventory.container.AbstractMaidContainer.m_6877_(AbstractMaidContainer.java:42) ~[touhoulittlemaid-1.20.1-release-1.1.9.jar%23264!/:1.1.9] {re:classloading}
```