### PR TITLE
feat: 更远射击距离，突破原版16的限制

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/TacCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/TacCompat.java
@@ -8,6 +8,8 @@ import com.github.tartaricacid.touhoulittlemaid.compat.tacz.client.GunGeckoAnima
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.client.GunMaidRender;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.event.GunHurtMaidEvent;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.task.TaskGunAttack;
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunNearestLivingEntitySensor;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.TaskManager;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.PlayState;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.builder.ILoopType;
@@ -16,6 +18,7 @@ import com.github.tartaricacid.touhoulittlemaid.geckolib3.geo.animated.AnimatedG
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -46,6 +49,19 @@ public class TacCompat {
     public static boolean isGrenade(ItemStack itemStack) {
         // TODO 手雷还没有
         return false;
+    }
+
+    public static boolean isGunTask(EntityMaid maid) {
+        if (INSTALLED) {
+            return GunNearestLivingEntitySensor.isGunTask(maid);
+        }
+        return false;
+    }
+
+    public static void doGunTick(ServerLevel world, EntityMaid maid) {
+        if (INSTALLED) {
+            GunNearestLivingEntitySensor.doGunTick(world, maid);
+        }
     }
 
     @Nullable

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunAttackStrafingTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunAttackStrafingTask.java
@@ -1,5 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunNearestLivingEntitySensor;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.google.common.collect.ImmutableMap;
 import com.tacz.guns.api.item.IGun;
@@ -30,7 +31,6 @@ public class GunAttackStrafingTask extends Behavior<EntityMaid> {
         return IGun.mainhandHoldGun(owner) &&
                owner.getBrain().getMemory(MemoryModuleType.ATTACK_TARGET)
                        .filter(Entity::isAlive)
-                       .filter(e -> owner.isWithinRestriction(e.blockPosition()))
                        .isPresent();
     }
 
@@ -45,8 +45,8 @@ public class GunAttackStrafingTask extends Behavior<EntityMaid> {
             double distance = owner.distanceTo(target);
             float maxAttackDistance = owner.getRestrictRadius();
 
-            // 如果在最大攻击距离之内，而且看见的时长足够长
-            if (distance < maxAttackDistance) {
+            // 如果在最大攻击距离（128）之内，而且看见的时长足够长
+            if (distance < GunNearestLivingEntitySensor.getRadiusSearchRange()) {
                 ++this.strafingTime;
             } else {
                 this.strafingTime = -1;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunShootTargetTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunShootTargetTask.java
@@ -1,5 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunBehaviorUtils;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.google.common.collect.ImmutableMap;
 import com.tacz.guns.api.TimelessAPI;
@@ -35,7 +36,7 @@ public class GunShootTargetTask extends Behavior<EntityMaid> {
         Optional<LivingEntity> memory = owner.getBrain().getMemory(MemoryModuleType.ATTACK_TARGET);
         if (memory.isPresent()) {
             LivingEntity target = memory.get();
-            return IGun.mainhandHoldGun(owner) && BehaviorUtils.canSee(owner, target);
+            return IGun.mainhandHoldGun(owner) && GunBehaviorUtils.canSee(owner, target);
         }
         return false;
     }
@@ -53,9 +54,9 @@ public class GunShootTargetTask extends Behavior<EntityMaid> {
     @Override
     protected void tick(ServerLevel worldIn, EntityMaid owner, long gameTime) {
         owner.getBrain().getMemory(MemoryModuleType.ATTACK_TARGET).ifPresent((target) -> {
-            BehaviorUtils.lookAtEntity(owner, target);
-
-            boolean canSee = BehaviorUtils.canSee(owner, target);
+            //实际上按照原版mc判定是看不见的，强行看见并朝向（没关就是开了？）
+            owner.getLookControl().setLookAt(target.getX(), target.getY(), target.getZ());
+            boolean canSee = GunBehaviorUtils.canSee(owner, target);
             boolean seeTimeMoreThanZero = this.seeTime > 0;
 
             // 如果两者不一致，重置看见时间

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunWalkToTarget.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunWalkToTarget.java
@@ -1,6 +1,7 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai;
 
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunBehaviorUtils;
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunNearestLivingEntitySensor;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.mojang.datafixers.kinds.IdF;
 import com.mojang.datafixers.kinds.OptionalBox;
@@ -16,7 +17,6 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
 import net.minecraft.world.entity.ai.memory.WalkTarget;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 public class GunWalkToTarget {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunWalkToTarget.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/ai/GunWalkToTarget.java
@@ -1,5 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunBehaviorUtils;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.mojang.datafixers.kinds.IdF;
 import com.mojang.datafixers.kinds.OptionalBox;
@@ -42,8 +43,7 @@ public class GunWalkToTarget {
                                                  MemoryAccessor<OptionalBox.Mu, NearestVisibleLivingEntities> livingEntitiesMemory) {
         return (level, maid, gameTime) -> {
             LivingEntity target = maidInstance.get(entityMemory);
-            Optional<NearestVisibleLivingEntities> optional = maidInstance.tryGet(livingEntitiesMemory);
-            if (optional.isPresent() && optional.get().contains(target) && isWithinRestriction(maid, target)) {
+            if (GunBehaviorUtils.canSee(maid, target) && isWithinRestriction(maid, target)) {
                 walkTargetMemory.erase();
             } else {
                 positionMemory.set(new EntityTracker(target, true));

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/task/TaskGunAttack.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/task/TaskGunAttack.java
@@ -6,6 +6,7 @@ import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunAttackStrafing
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunShootTargetTask;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunWalkToTarget;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunBehaviorUtils;
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunNearestLivingEntitySensor;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.init.InitSounds;
 import com.github.tartaricacid.touhoulittlemaid.util.SoundUtil;
@@ -78,6 +79,6 @@ public class TaskGunAttack implements IAttackTask {
     }
 
     private boolean farAway(LivingEntity target, EntityMaid maid) {
-        return maid.distanceTo(target) > maid.getRestrictRadius();
+        return maid.distanceTo(target) > GunNearestLivingEntitySensor.getRadiusSearchRange();
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/task/TaskGunAttack.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/task/TaskGunAttack.java
@@ -5,6 +5,7 @@ import com.github.tartaricacid.touhoulittlemaid.api.task.IAttackTask;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunAttackStrafingTask;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunShootTargetTask;
 import com.github.tartaricacid.touhoulittlemaid.compat.tacz.ai.GunWalkToTarget;
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils.GunBehaviorUtils;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.init.InitSounds;
 import com.github.tartaricacid.touhoulittlemaid.util.SoundUtil;
@@ -52,7 +53,7 @@ public class TaskGunAttack implements IAttackTask {
 
     @Override
     public List<Pair<Integer, BehaviorControl<? super EntityMaid>>> createBrainTasks(EntityMaid maid) {
-        BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::mainhandHoldGun, IAttackTask::findFirstValidAttackTarget);
+        BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::mainhandHoldGun, GunBehaviorUtils::findFirstValidAttackTarget);
         BehaviorControl<EntityMaid> findTargetTask = StopAttackingIfTargetInvalid.create(target -> !mainhandHoldGun(maid) || farAway(target, maid));
         BehaviorControl<EntityMaid> gunWalkTargetTask = GunWalkToTarget.create(0.6f);
         BehaviorControl<EntityMaid> gunAttackStrafingTask = new GunAttackStrafingTask();

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunBehaviorUtils.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunBehaviorUtils.java
@@ -1,32 +1,59 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils;
 
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.tacz.guns.api.TimelessAPI;
+import com.tacz.guns.api.item.GunTabType;
+import com.tacz.guns.api.item.IGun;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.behavior.BehaviorUtils;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 public class GunBehaviorUtils {
-
-    //可见性校验工具，来自于Sensor
-    private static final TargetingConditions TARGET_CONDITIONS = TargetingConditions.forNonCombat().range(64.0D);
+    // 可见性校验工具，来自于 Sensor
+    // 依据枪械种类，可以区分为远、中、近三类
+    private static final TargetingConditions LONG_DISTANCE_TARGET_CONDITIONS = TargetingConditions.forNonCombat().range(128);
+    private static final TargetingConditions MEDIUM_DISTANCE_TARGET_CONDITIONS = TargetingConditions.forNonCombat().range(96);
+    private static final TargetingConditions NEAR_DISTANCE_TARGET_CONDITIONS = TargetingConditions.forNonCombat().range(64);
 
     //可见性方法，来自于Sensor类
-    public static boolean canSee(LivingEntity pLivingEntity, LivingEntity pTarget) {
-        return TARGET_CONDITIONS.test(pLivingEntity, pTarget);
+    public static boolean canSee(EntityMaid maid, LivingEntity target) {
+        ItemStack handItem = maid.getMainHandItem();
+        IGun iGun = IGun.getIGunOrNull(handItem);
+        if (iGun != null) {
+            ResourceLocation gunId = iGun.getGunId(handItem);
+            return TimelessAPI.getCommonGunIndex(gunId).map(index -> {
+                String type = index.getType();
+                // 狙击枪？用远距离模式
+                String sniper = GunTabType.SNIPER.name().toLowerCase(Locale.ENGLISH);
+                if (sniper.equals(type)) {
+                    return LONG_DISTANCE_TARGET_CONDITIONS.test(maid, target);
+                }
+                // 霰弹枪？手枪？近距离模式
+                String shotgun = GunTabType.SHOTGUN.name().toLowerCase(Locale.ENGLISH);
+                String pistol = GunTabType.PISTOL.name().toLowerCase(Locale.ENGLISH);
+                if (shotgun.equals(type) || pistol.equals(type)) {
+                    return NEAR_DISTANCE_TARGET_CONDITIONS.test(maid, target);
+                }
+                // 其他情况，中等距离
+                return MEDIUM_DISTANCE_TARGET_CONDITIONS.test(maid, target);
+            }).orElse(BehaviorUtils.canSee(maid, target));
+        }
+        return BehaviorUtils.canSee(maid, target);
     }
 
-    //寻找第一个可见目标，使用独立的方法，区别于IAttackTask
+    // 寻找第一个可见目标，使用独立的方法，区别于 IAttackTask
     public static Optional<? extends LivingEntity> findFirstValidAttackTarget(EntityMaid maid) {
         if (maid.getBrain().getMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES).isPresent()) {
             List<LivingEntity> list = maid.getBrain().getMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES).get();
-            return list.stream().filter((e) -> maid.canAttack(e) && maid.isWithinRestriction(e.blockPosition()) &&
-                    GunBehaviorUtils.canSee(maid, e)).findAny();
+            return list.stream().filter(e -> maid.canAttack(e) && GunBehaviorUtils.canSee(maid, e)).findAny();
         }
         return Optional.empty();
     }
-
-
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunBehaviorUtils.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunBehaviorUtils.java
@@ -1,0 +1,32 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GunBehaviorUtils {
+
+    //可见性校验工具，来自于Sensor
+    private static final TargetingConditions TARGET_CONDITIONS = TargetingConditions.forNonCombat().range(64.0D);
+
+    //可见性方法，来自于Sensor类
+    public static boolean canSee(LivingEntity pLivingEntity, LivingEntity pTarget) {
+        return TARGET_CONDITIONS.test(pLivingEntity, pTarget);
+    }
+
+    //寻找第一个可见目标，使用独立的方法，区别于IAttackTask
+    public static Optional<? extends LivingEntity> findFirstValidAttackTarget(EntityMaid maid) {
+        if (maid.getBrain().getMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES).isPresent()) {
+            List<LivingEntity> list = maid.getBrain().getMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES).get();
+            return list.stream().filter((e) -> maid.canAttack(e) && maid.isWithinRestriction(e.blockPosition()) &&
+                    GunBehaviorUtils.canSee(maid, e)).findAny();
+        }
+        return Optional.empty();
+    }
+
+
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunNearestLivingEntitySensor.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/tacz/utils/GunNearestLivingEntitySensor.java
@@ -1,0 +1,40 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.tacz.utils;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.task.TaskGunAttack;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+import net.minecraft.world.phys.AABB;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class GunNearestLivingEntitySensor {
+    private static final int VERTICAL_SEARCH_RANGE = 64;
+    private static final int RADIUS_SEARCH_RANGE = 128;
+
+    public static boolean isGunTask(EntityMaid maid) {
+        return maid.getTask().getUid().equals(TaskGunAttack.UID);
+    }
+
+    public static void doGunTick(ServerLevel world, EntityMaid maid) {
+        AABB aabb;
+        if (maid.hasRestriction()) {
+            aabb = new AABB(maid.getRestrictCenter()).inflate(RADIUS_SEARCH_RANGE, VERTICAL_SEARCH_RANGE, RADIUS_SEARCH_RANGE);
+        } else {
+            aabb = maid.getBoundingBox().inflate(RADIUS_SEARCH_RANGE, VERTICAL_SEARCH_RANGE, RADIUS_SEARCH_RANGE);
+        }
+        List<LivingEntity> list = world.getEntitiesOfClass(LivingEntity.class, aabb, (entity) -> entity != maid && entity.isAlive());
+        list.sort(Comparator.comparingDouble(maid::distanceToSqr));
+        Brain<EntityMaid> brain = maid.getBrain();
+        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, list);
+        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(maid, list));
+    }
+
+    public static int getRadiusSearchRange() {
+        return RADIUS_SEARCH_RANGE;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/sensor/MaidNearestLivingEntitySensor.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/sensor/MaidNearestLivingEntitySensor.java
@@ -1,5 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.entity.ai.brain.sensor;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.tacz.TacCompat;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.server.level.ServerLevel;
@@ -18,6 +19,13 @@ public class MaidNearestLivingEntitySensor extends Sensor<EntityMaid> {
     private static final int VERTICAL_SEARCH_RANGE = 4;
 
     protected void doTick(ServerLevel world, EntityMaid maid) {
+        // 兼容 tac
+        if (TacCompat.isGunTask(maid)) {
+            TacCompat.doGunTick(world, maid);
+            return;
+        }
+
+        // 正常搜索
         float radius = maid.getRestrictRadius();
         AABB aabb;
         if (maid.hasRestriction()) {


### PR DESCRIPTION
1. 新增可见判断方法，增加可见判定距离，替换可见逻辑
2. 索敌逻辑改动，从NEAREST_VISIBLE_LIVING_ENTITIES获取改为从NEAREST_LIVING_ENTITIES中获取，因为NEAREST_VISIBLE_LIVING_ENTITIES无法突破Sensor的底层距离限制
3. 替换了 BehaviorUtils.lookAtEntity方法，该方法也只能有16格距离

