### PR TITLE
1.优化墓碑物品取出逻辑;2.修改女仆近战攻击间隔,像玩家一样计算

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityTombstone.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityTombstone.java
@@ -1,8 +1,10 @@
 package com.github.tartaricacid.touhoulittlemaid.entity.item;
 
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.world.data.MaidWorldData;
 import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -24,6 +26,8 @@ import net.neoforged.neoforge.items.ItemStackHandler;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.UUID;
+
+import static com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil.canItemInsert;
 
 public class EntityTombstone extends Entity {
     public static final EntityType<EntityTombstone> TYPE = EntityType.Builder.<EntityTombstone>of(EntityTombstone::new, MobCategory.MISC)
@@ -53,17 +57,45 @@ public class EntityTombstone extends Entity {
     public InteractionResult interact(Player player, InteractionHand hand) {
         ItemStack itemInHand = player.getItemInHand(hand);
         Ingredient ntrItem = EntityMaid.getNtrItem();
+
         // NTR 工具可以收回墓碑
         if (player.getUUID().equals(this.ownerId) || ntrItem.test(itemInHand)) {
+            boolean canTakeAll = true;
+            boolean isShiftDown = player.isShiftKeyDown();
+
+            // 第一步：预检查所有物品是否能被玩家容纳（不实际提取物品）
+            for (int i = 0; i < this.items.getSlots(); i++) {
+                ItemStack stack = this.items.getStackInSlot(i);
+                if (stack.isEmpty()) continue;
+
+                // 如果玩家没按Shift，且物品无法插入背包，则标记为不能全部取出
+                if (!isShiftDown && !canItemInsert(player, stack)) {
+                    canTakeAll = false;
+                    break; // 一旦发现有物品不能插入，立即中断检查
+                }
+            }
+
+            // 如果不能全部取出且没按Shift，直接返回失败（不处理任何物品）
+            if (!canTakeAll && !isShiftDown) {
+                TouhouLittleMaid.LOGGER.info("背包已满,物品插入失败");
+                return InteractionResult.FAIL;
+            }
+
+            // 第二步：确认可以处理后，才实际提取并给予物品
             for (int i = 0; i < this.items.getSlots(); i++) {
                 int size = this.items.getSlotLimit(i);
                 ItemStack extractItem = this.items.extractItem(i, size, false);
-                ItemHandlerHelper.giveItemToPlayer(player, extractItem);
+                if (!extractItem.isEmpty()) {
+                    ItemHandlerHelper.giveItemToPlayer(player, extractItem);
+                }
             }
+
+            // 所有物品处理完毕后，再销毁实体
             this.discard();
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 
+        // 其他逻辑...
         if (!player.level.isClientSide && hand == InteractionHand.MAIN_HAND) {
             ItemStack stack = Arrays.stream(ntrItem.getItems()).findFirst().orElse(ItemStack.EMPTY);
             Component displayName = stack.getDisplayName();

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityTombstone.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityTombstone.java
@@ -1,10 +1,8 @@
 package com.github.tartaricacid.touhoulittlemaid.entity.item;
 
-import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.world.data.MaidWorldData;
 import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -58,27 +56,28 @@ public class EntityTombstone extends Entity {
         ItemStack itemInHand = player.getItemInHand(hand);
         Ingredient ntrItem = EntityMaid.getNtrItem();
 
+        // 只能主手触发
+        if (hand != InteractionHand.MAIN_HAND) {
+            return InteractionResult.PASS;
+        }
+
         // NTR 工具可以收回墓碑
         if (player.getUUID().equals(this.ownerId) || ntrItem.test(itemInHand)) {
-            boolean canTakeAll = true;
-            boolean isShiftDown = player.isShiftKeyDown();
-
             // 第一步：预检查所有物品是否能被玩家容纳（不实际提取物品）
-            for (int i = 0; i < this.items.getSlots(); i++) {
-                ItemStack stack = this.items.getStackInSlot(i);
-                if (stack.isEmpty()) continue;
-
-                // 如果玩家没按Shift，且物品无法插入背包，则标记为不能全部取出
-                if (!isShiftDown && !canItemInsert(player, stack)) {
-                    canTakeAll = false;
-                    break; // 一旦发现有物品不能插入，立即中断检查
+            // 如果玩家按下了 Shift 键，则强制取出
+            if (!player.isSecondaryUseActive()) {
+                for (int i = 0; i < this.items.getSlots(); i++) {
+                    ItemStack stack = this.items.getStackInSlot(i);
+                    if (stack.isEmpty() || canItemInsert(player, stack)) {
+                        continue;
+                    }
+                    // 一旦发现有物品不能插入，立即中断检查
+                    if (!player.level.isClientSide) {
+                        player.sendSystemMessage(Component.translatable("message.touhou_little_maid.tombstone.player_inventory_full.1"));
+                        player.sendSystemMessage(Component.translatable("message.touhou_little_maid.tombstone.player_inventory_full.2"));
+                    }
+                    return InteractionResult.FAIL;
                 }
-            }
-
-            // 如果不能全部取出且没按Shift，直接返回失败（不处理任何物品）
-            if (!canTakeAll && !isShiftDown) {
-                TouhouLittleMaid.LOGGER.info("背包已满,物品插入失败");
-                return InteractionResult.FAIL;
             }
 
             // 第二步：确认可以处理后，才实际提取并给予物品
@@ -96,7 +95,7 @@ public class EntityTombstone extends Entity {
         }
 
         // 其他逻辑...
-        if (!player.level.isClientSide && hand == InteractionHand.MAIN_HAND) {
+        if (!player.level.isClientSide) {
             ItemStack stack = Arrays.stream(ntrItem.getItems()).findFirst().orElse(ItemStack.EMPTY);
             Component displayName = stack.getDisplayName();
             player.sendSystemMessage(Component.translatable("message.touhou_little_maid.tombstone.not_yours.1"));

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/TaskAttack.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/TaskAttack.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -20,10 +21,12 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.behavior.*;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 public class TaskAttack implements IAttackTask {
@@ -49,7 +52,7 @@ public class TaskAttack implements IAttackTask {
         BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::hasAssaultWeapon, IAttackTask::findFirstValidAttackTarget);
         BehaviorControl<EntityMaid> findTargetTask = StopAttackingIfTargetInvalid.create(target -> !hasAssaultWeapon(maid) || farAway(target, maid));
         BehaviorControl<Mob> moveToTargetTask = SetWalkTargetFromAttackTargetIfTargetOutOfReach.create(0.6f);
-        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(20);
+        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(calculateCooldown(maid));
         MaidUseShieldTask maidUseShieldTask = new MaidUseShieldTask();
 
         return Lists.newArrayList(
@@ -65,7 +68,7 @@ public class TaskAttack implements IAttackTask {
     public List<Pair<Integer, BehaviorControl<? super EntityMaid>>> createRideBrainTasks(EntityMaid maid) {
         BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::hasAssaultWeapon, IAttackTask::findFirstValidAttackTarget);
         BehaviorControl<EntityMaid> findTargetTask = StopAttackingIfTargetInvalid.create(target -> !hasAssaultWeapon(maid) || farAway(target, maid));
-        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(20);
+        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(calculateCooldown(maid));
         MaidUseShieldTask maidUseShieldTask = new MaidUseShieldTask();
 
         return Lists.newArrayList(
@@ -124,5 +127,41 @@ public class TaskAttack implements IAttackTask {
             return maid.getOwner().distanceTo(target) > radius;
         }
         return maid.distanceTo(target) > radius;
+    }
+
+    private int calculateCooldown(EntityMaid maid){
+        // 1. 基础攻击速度
+        double attackSpeed = 4;
+
+        // 2. 叠加手持武器的攻击速度修正
+        ItemStack weapon = maid.getMainHandItem();
+        if(!weapon.isEmpty()){
+            AtomicReference<Double> itemSpeed = new AtomicReference<>((double) 0);
+            ItemAttributeModifiers attributeModifiers = weapon.getAttributeModifiers();
+            attributeModifiers.forEach(EquipmentSlot.MAINHAND,(a,b)->{
+                if(b.is(ResourceLocation.fromNamespaceAndPath("minecraft","base_attack_speed"))){
+                    itemSpeed.set(b.amount());
+                }
+            });
+            attackSpeed+=itemSpeed.get();
+        }
+        // 3. 叠加状态效果的影响（急迫/挖掘疲劳）
+        // 急迫：每级增加10%攻击速度（公式：1 + 0.1 * 等级）
+        if (maid.hasEffect(MobEffects.DIG_SPEED)) {
+            int amplifier = maid.getEffect(MobEffects.DIG_SPEED).getAmplifier();
+            attackSpeed *= (1.0 + 0.1 * (amplifier + 1));
+        }
+
+        // 挖掘疲劳：每级降低10%攻击速度（公式：1 - 0.1 * 等级）
+        if (maid.hasEffect(MobEffects.DIG_SLOWDOWN)) {
+            int amplifier = maid.getEffect(MobEffects.DIG_SLOWDOWN).getAmplifier();
+            attackSpeed *= (1.0 - 0.1 * (amplifier + 1));
+        }
+
+        // 防御性处理：确保攻击速度不会低于极小值（避免后续除零）
+        attackSpeed=Math.max(attackSpeed,0.1);
+        int result = (int) Math.round(20.0 / attackSpeed);
+        //TouhouLittleMaid.LOGGER.info("计算结果:"+result);
+        return result;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/TaskAttack.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/TaskAttack.java
@@ -12,7 +12,6 @@ import com.google.common.collect.Lists;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -21,12 +20,10 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.behavior.*;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 public class TaskAttack implements IAttackTask {
@@ -52,7 +49,7 @@ public class TaskAttack implements IAttackTask {
         BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::hasAssaultWeapon, IAttackTask::findFirstValidAttackTarget);
         BehaviorControl<EntityMaid> findTargetTask = StopAttackingIfTargetInvalid.create(target -> !hasAssaultWeapon(maid) || farAway(target, maid));
         BehaviorControl<Mob> moveToTargetTask = SetWalkTargetFromAttackTargetIfTargetOutOfReach.create(0.6f);
-        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(calculateCooldown(maid));
+        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(20);
         MaidUseShieldTask maidUseShieldTask = new MaidUseShieldTask();
 
         return Lists.newArrayList(
@@ -68,7 +65,7 @@ public class TaskAttack implements IAttackTask {
     public List<Pair<Integer, BehaviorControl<? super EntityMaid>>> createRideBrainTasks(EntityMaid maid) {
         BehaviorControl<EntityMaid> supplementedTask = StartAttacking.create(this::hasAssaultWeapon, IAttackTask::findFirstValidAttackTarget);
         BehaviorControl<EntityMaid> findTargetTask = StopAttackingIfTargetInvalid.create(target -> !hasAssaultWeapon(maid) || farAway(target, maid));
-        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(calculateCooldown(maid));
+        BehaviorControl<Mob> attackTargetTask = MeleeAttack.create(20);
         MaidUseShieldTask maidUseShieldTask = new MaidUseShieldTask();
 
         return Lists.newArrayList(
@@ -127,41 +124,5 @@ public class TaskAttack implements IAttackTask {
             return maid.getOwner().distanceTo(target) > radius;
         }
         return maid.distanceTo(target) > radius;
-    }
-
-    private int calculateCooldown(EntityMaid maid){
-        // 1. 基础攻击速度
-        double attackSpeed = 4;
-
-        // 2. 叠加手持武器的攻击速度修正
-        ItemStack weapon = maid.getMainHandItem();
-        if(!weapon.isEmpty()){
-            AtomicReference<Double> itemSpeed = new AtomicReference<>((double) 0);
-            ItemAttributeModifiers attributeModifiers = weapon.getAttributeModifiers();
-            attributeModifiers.forEach(EquipmentSlot.MAINHAND,(a,b)->{
-                if(b.is(ResourceLocation.fromNamespaceAndPath("minecraft","base_attack_speed"))){
-                    itemSpeed.set(b.amount());
-                }
-            });
-            attackSpeed+=itemSpeed.get();
-        }
-        // 3. 叠加状态效果的影响（急迫/挖掘疲劳）
-        // 急迫：每级增加10%攻击速度（公式：1 + 0.1 * 等级）
-        if (maid.hasEffect(MobEffects.DIG_SPEED)) {
-            int amplifier = maid.getEffect(MobEffects.DIG_SPEED).getAmplifier();
-            attackSpeed *= (1.0 + 0.1 * (amplifier + 1));
-        }
-
-        // 挖掘疲劳：每级降低10%攻击速度（公式：1 - 0.1 * 等级）
-        if (maid.hasEffect(MobEffects.DIG_SLOWDOWN)) {
-            int amplifier = maid.getEffect(MobEffects.DIG_SLOWDOWN).getAmplifier();
-            attackSpeed *= (1.0 - 0.1 * (amplifier + 1));
-        }
-
-        // 防御性处理：确保攻击速度不会低于极小值（避免后续除零）
-        attackSpeed=Math.max(attackSpeed,0.1);
-        int result = (int) Math.round(20.0 / attackSpeed);
-        //TouhouLittleMaid.LOGGER.info("计算结果:"+result);
-        return result;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
@@ -10,10 +10,13 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemHandlerHelper;
+import net.neoforged.neoforge.items.wrapper.PlayerMainInvWrapper;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -149,5 +152,31 @@ public final class ItemsUtil {
             ItemEntity itemEntity = new ItemEntity(maid.level(), maid.getX(), maid.getY() + 0.5, maid.getZ(), stack);
             maid.level.addFreshEntity(itemEntity);
         }
+    }
+
+    /**
+     * 判断玩家主背包（包括快捷栏）能否插入物品
+     *
+     * @param player 要检查的玩家
+     *
+     * @return 如果背包已满返回true，否则返回false
+     */
+    public static boolean canItemInsert(Player player,ItemStack testStack) {
+        // 获取玩家主背包的物品处理器（与giveItemToPlayer使用相同的包装器）
+        IItemHandler inventory = new PlayerMainInvWrapper(player.getInventory());
+
+        // 遍历所有背包槽位
+        for (int i = 0; i < inventory.getSlots(); i++) {
+            // 模拟插入物品（第三个参数为true表示仅测试，不实际修改物品栏）
+            ItemStack remainder = inventory.insertItem(i, testStack, true);
+
+            // 如果插入后没有剩余，说明该槽位可以容纳物品
+            if (remainder.isEmpty()) {
+                return true;
+            }
+        }
+
+        // 所有槽位都无法容纳测试物品
+        return false;
     }
 }

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.json
@@ -543,6 +543,8 @@
   "message.touhou_little_maid.saddle.how_to_eject": "Right click again with the saddle in hand to eject the maid",
   "message.touhou_little_maid.tombstone.not_yours.1": "This maid tombstone is not yours!",
   "message.touhou_little_maid.tombstone.not_yours.2": "if you are a server admin, please right click with the item: ",
+  "message.touhou_little_maid.tombstone.player_inventory_full.1": "Player's inventory is full, please clear some space before retrieving maid's items",
+  "message.touhou_little_maid.tombstone.player_inventory_full.2": "You can sneak & right click to force retrieving maid's items",
   "message.touhou_little_maid.servant_bell.show_pos": "The maid is on an unloaded chunk, please follow the position hint to find it",
   "message.touhou_little_maid.servant_bell.not_same_dimension": "You are not in the same dimension as your maid. The maid is in the %s dimension",
   "message.touhou_little_maid.servant_bell.no_result": "No maids were found",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -543,6 +543,8 @@
   "message.touhou_little_maid.saddle.how_to_eject": "使用鞍再次右击即可放下女仆",
   "message.touhou_little_maid.tombstone.not_yours.1": "这个女仆墓碑不是你的！",
   "message.touhou_little_maid.tombstone.not_yours.2": "如果你是服务器管理员，请使用这个物品来右击移除：",
+  "message.touhou_little_maid.tombstone.player_inventory_full.1": "玩家的物品栏已满，请在取回女仆物品之前清出一些空间",
+  "message.touhou_little_maid.tombstone.player_inventory_full.2": "你也可以潜行右击来强制取回女仆物品",
   "message.touhou_little_maid.servant_bell.show_pos": "女仆在卸载区块上，请遵循坐标指引来找到她",
   "message.touhou_little_maid.servant_bell.not_same_dimension": "女仆和你不在同一维度，女仆在%s维度",
   "message.touhou_little_maid.servant_bell.no_result": "找不到女仆",


### PR DESCRIPTION
1.优化墓碑物品取出逻辑([issue#805](https://github.com/TartaricAcid/TouhouLittleMaid/issues/805))
如果玩家背包无法容纳墓碑中的所有物品,右键墓碑时不会取出.按住shift 的同时右键可以强制取出(无法容纳的物品掉落在地面)

2.修改女仆近战攻击间隔,像玩家一样计算([issue#830](https://github.com/TartaricAcid/TouhouLittleMaid/issues/830))
根据[Wiki](https://zh.minecraft.wiki/w/%E8%BF%91%E6%88%98%E6%94%BB%E5%87%BB?variant=zh-cn#%E6%94%BB%E5%87%BB%E5%86%B7%E5%8D%B4)上的介绍,设计了一个计算女仆攻击间隔的方法,而不是固定攻击冷却为20tick.
