### PR TITLE
允许鼠标滚轮翻页任务列表

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/AbstractMaidContainerGui.java
@@ -287,17 +287,10 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
 
     private void addTaskControlButton() {
         pageDown = new TouhouImageButton(leftPos - 72, topPos + 9, 16, 13, 93, 0, 14, TASK, (b) -> {
-            List<IMaidTask> tasks = TaskManager.getTaskIndex();
-            if (TASK_PAGE * TASK_COUNT_PER_PAGE + TASK_COUNT_PER_PAGE < tasks.size()) {
-                TASK_PAGE++;
-                init();
-            }
+            taskPageDown();
         });
         pageUp = new TouhouImageButton(leftPos - 89, topPos + 9, 16, 13, 110, 0, 14, TASK, (b) -> {
-            if (TASK_PAGE > 0) {
-                TASK_PAGE--;
-                init();
-            }
+            taskPageUp();
         });
         pageClose = new TouhouImageButton(leftPos - 19, topPos + 9, 13, 13, 127, 0, 14, TASK, (b) -> {
             TASK_LIST_OPEN = false;
@@ -309,6 +302,21 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
         pageUp.visible = TASK_LIST_OPEN;
         pageDown.visible = TASK_LIST_OPEN;
         pageClose.visible = TASK_LIST_OPEN;
+    }
+
+    private void taskPageUp() {
+        if (TASK_PAGE > 0) {
+            TASK_PAGE--;
+            init();
+        }
+    }
+
+    private  void taskPageDown() {
+        List<IMaidTask> tasks = TaskManager.getTaskIndex();
+        if (TASK_PAGE * TASK_COUNT_PER_PAGE + TASK_COUNT_PER_PAGE < tasks.size()) {
+            TASK_PAGE++;
+            init();
+        }
     }
 
     private void addTaskListButton() {
@@ -555,7 +563,8 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
 
     private void drawTaskListBg(GuiGraphics graphics) {
         if (TASK_LIST_OPEN) {
-            graphics.blit(TASK, leftPos - 93, topPos + 5, 0, 0, 92, 251);
+            Rect2i taskListArea = getTaskListArea();
+            graphics.blit(TASK, taskListArea.getX(), taskListArea.getY(), 0, 0, taskListArea.getWidth(), taskListArea.getHeight());
         }
     }
 
@@ -620,6 +629,10 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
         return TASK_LIST_OPEN;
     }
 
+    private Rect2i getTaskListArea() {
+        return new Rect2i(leftPos - 93, topPos + 5, 92, 251);
+    }
+
     // 获取女仆界面JERI屏蔽区域
     public List<Rect2i> getExclusionArea() {
         List<Rect2i> zones = new ArrayList<>();
@@ -627,9 +640,25 @@ public abstract class AbstractMaidContainerGui<T extends AbstractMaidContainer> 
         zones.add(new Rect2i(leftPos + 251, topPos + 28 + 9, 21, 99));
         // 任务列表
         if (isTaskListOpen()) {
-            zones.add(new Rect2i(leftPos - 93, topPos + 5, 92, 251));
+            zones.add(getTaskListArea());
         }
         return zones;
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+        if (TASK_LIST_OPEN && getTaskListArea().contains((int) mouseX, (int) mouseY)) {
+            if (scrollY > 0) {
+                // 向上滚，相当于点击 "Page Up"
+                taskPageUp();
+            } else {
+                // 向下滚，相当于点击 "Page Down"
+                taskPageDown();
+            }
+            return true;
+        }
+
+        return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
     }
 
     public EntityMaid getMaid() {


### PR DESCRIPTION
- 抽取 `taskPageUp` 和 `taskPagedown` 为单独函数
- 抽取 `getTaskListArea` 为单独函数
- 添加 `mouseScrolled` 处理滚动逻辑

用抽取的方法替换了此类中所有翻页和获取任务列表区域的地方，确保行为统一和单一数据源