### PR TITLE
往河童的罗盘写入后续坐标时，检查所处维度是否一致

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemKappaCompass.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemKappaCompass.java
@@ -135,6 +135,7 @@ public class ItemKappaCompass extends Item {
             compass.remove(KAPPA_COMPASS_DIMENSION);
             sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.clear"));
         } else {
+            ResourceLocation dimension = getDimension(compass);
             int recordCount = getRecordCount(compass);
             if (recordCount >= 3) {
                 sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.full"));
@@ -144,12 +145,20 @@ public class ItemKappaCompass extends Item {
                     sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away"));
                     return super.useOn(context);
                 }
+                if (dimension != null && !player.level.dimension().location().equals(dimension)) {
+                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away_dimension"));
+                    return super.useOn(context);
+                }
                 addPoint(Activity.REST, clickedPos, compass);
                 sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.sleep", clickedPos.getX(), clickedPos.getY(), clickedPos.getZ()));
             } else if (recordCount == 1) {
                 BlockPos workPos = getPoint(Activity.WORK, compass);
                 if (workPos != null && workPos.distSqr(clickedPos) > 64 * 64) {
                     sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away"));
+                    return super.useOn(context);
+                }
+                if (dimension != null && !player.level.dimension().location().equals(dimension)) {
+                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away_dimension"));
                     return super.useOn(context);
                 }
                 addPoint(Activity.IDLE, clickedPos, compass);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemKappaCompass.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/item/ItemKappaCompass.java
@@ -146,7 +146,7 @@ public class ItemKappaCompass extends Item {
                     return super.useOn(context);
                 }
                 if (dimension != null && !player.level.dimension().location().equals(dimension)) {
-                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away_dimension"));
+                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.diff_dimension"));
                     return super.useOn(context);
                 }
                 addPoint(Activity.REST, clickedPos, compass);
@@ -158,7 +158,7 @@ public class ItemKappaCompass extends Item {
                     return super.useOn(context);
                 }
                 if (dimension != null && !player.level.dimension().location().equals(dimension)) {
-                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.far_away_dimension"));
+                    sendMessage(player, Component.translatable("message.touhou_little_maid.kappa_compass.diff_dimension"));
                     return super.useOn(context);
                 }
                 addPoint(Activity.IDLE, clickedPos, compass);

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.json
@@ -528,6 +528,7 @@
   "message.touhou_little_maid.kappa_compass.maid_write": "Successfully saved positions to the maid",
   "message.touhou_little_maid.kappa_compass.maid_clear": "Successfully cleared the maid's positions",
   "message.touhou_little_maid.kappa_compass.maid_dimension_check": "The position's dimension does not match the maid's current dimension",
+  "message.touhou_little_maid.kappa_compass.diff_dimension": "The recorded dimension does not match your current dimension",
   "message.touhou_little_maid.kappa_compass.no_data": "This compass has not recorded any positions",
   "message.touhou_little_maid.kappa_compass.work": "§a▍ §7Work Pos: [%d, %d, %d§7]",
   "message.touhou_little_maid.kappa_compass.idle": "§a▍ §7Idle Pos: [%d, %d, %d§7]",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -524,6 +524,7 @@
   "message.touhou_little_maid.kappa_compass.clear": "所有的坐标已经清除",
   "message.touhou_little_maid.kappa_compass.full": "坐标已满，请Shift右击进行清除",
   "message.touhou_little_maid.kappa_compass.far_away": "距离前一个坐标过远，最大只能为64",
+  "message.touhou_little_maid.kappa_compass.far_away_dimension": "距离前一个坐标过远，必须处于同一维度",
   "message.touhou_little_maid.kappa_compass.maid_write": "成功为女仆写入坐标",
   "message.touhou_little_maid.kappa_compass.maid_clear": "成功清除女仆的坐标",
   "message.touhou_little_maid.kappa_compass.maid_dimension_check": "记录的维度与当前女仆所处的维度不相同",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -524,7 +524,7 @@
   "message.touhou_little_maid.kappa_compass.clear": "所有的坐标已经清除",
   "message.touhou_little_maid.kappa_compass.full": "坐标已满，请Shift右击进行清除",
   "message.touhou_little_maid.kappa_compass.far_away": "距离前一个坐标过远，最大只能为64",
-  "message.touhou_little_maid.kappa_compass.far_away_dimension": "距离前一个坐标过远，必须处于同一维度",
+  "message.touhou_little_maid.kappa_compass.diff_dimension": "罗盘记录的维度与当前所在维度不一致",
   "message.touhou_little_maid.kappa_compass.maid_write": "成功为女仆写入坐标",
   "message.touhou_little_maid.kappa_compass.maid_clear": "成功清除女仆的坐标",
   "message.touhou_little_maid.kappa_compass.maid_dimension_check": "记录的维度与当前女仆所处的维度不相同",


### PR DESCRIPTION
河童的罗盘在写入后续坐标时会静默地替换掉之前保存的维度，这个设计感觉有点不统一，因为点和点之间的距离过远是会提示且保存失败的。