### PR TITLE
修复魔法咏唱动画控制器逻辑

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
@@ -401,7 +401,7 @@ public final class AnimationManager {
             // 尝试获取自定义动画
             AnimationBuilder builder = provider.getAnimationBuilder(maid, state);
             if (builder != null) {
-                if (lastPhase == IMagicCastingState.CastingPhase.NONE) {
+                if (lastPhase != IMagicCastingState.CastingPhase.START && lastPhase != IMagicCastingState.CastingPhase.CASTING) {
                     controller.markNeedsReload();
                 }
                 controller.setAnimation(builder);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
@@ -374,6 +374,8 @@ public final class AnimationManager {
 
             // 如果咏唱被取消，跳过当前提供器，检查下一个
             if (state != null && state.isCancelled()) {
+                // 清理取消标记，避免提供器没有清除状态
+                state.setCancelled(false);
                 continue;
             }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/AnimationManager.java
@@ -14,7 +14,6 @@ import com.github.tartaricacid.touhoulittlemaid.entity.passive.MaidGameRecordMan
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.PlayState;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.builder.AnimationBuilder;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.builder.ILoopType;
-import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.builder.RawAnimation;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.event.predicate.AnimationEvent;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.resource.GeckoLibCache;
 import com.github.tartaricacid.touhoulittlemaid.network.message.MaidAnimationMessage;
@@ -364,41 +363,58 @@ public final class AnimationManager {
         if (maid == null) {
             return PlayState.STOP;
         }
-        if (event.getController().getAnimationState() != com.github.tartaricacid.touhoulittlemaid.geckolib3.core.AnimationState.STOPPED
-            && event.getController().getCurrentAnimation() != null
-            && event.getController().getCurrentAnimation().loop ==  ILoopType.EDefaultLoopTypes.PLAY_ONCE) {
-            return PlayState.CONTINUE;
-        }
+
+        var controller = event.getController();
+        var geckoEntity = event.getAnimatableEntity();
+        var lastPhase = geckoEntity.getLastCastingPhase();
 
         // 遍历所有注册的提供器，按优先级顺序
         for (IMagicCastingAnimationProvider provider : MagicCastingAnimationManager.getProviders()) {
             IMagicCastingState state = provider.getMagicCastingState(maid);
 
-            // 检查状态是否有效
-            if (state == null || state.getCurrentPhase() == IMagicCastingState.CastingPhase.NONE) {
+            // 如果咏唱被取消，跳过当前提供器，检查下一个
+            if (state != null && state.isCancelled()) {
                 continue;
             }
 
-            // 如果咏唱被取消，跳过当前提供器，检查下一个附属
-            if (state.isCancelled()) {
+            // 获取当前 phase
+            var currentPhase = (state != null) ? state.getCurrentPhase() : IMagicCastingState.CastingPhase.NONE;
+
+            // 检查状态是否有效
+            if (currentPhase == IMagicCastingState.CastingPhase.NONE) {
+                // 当前 phase 为 NONE，检查是否需要让动画播放完毕
+                // 从 INSTANT 或 END 过渡到 NONE 时，继续播放直到动画结束
+                if ((lastPhase == IMagicCastingState.CastingPhase.INSTANT || lastPhase == IMagicCastingState.CastingPhase.END)
+                        && controller.getAnimationState() != com.github.tartaricacid.touhoulittlemaid.geckolib3.core.AnimationState.STOPPED) {
+                    return PlayState.CONTINUE;
+                }
+                // 从 START 或 CASTING 过渡到 NONE 时，允许终止
+                geckoEntity.setLastCastingPhase(IMagicCastingState.CastingPhase.NONE);
                 continue;
             }
+
+            // 更新 lastPhase
+            geckoEntity.setLastCastingPhase(currentPhase);
 
             // 尝试获取自定义动画
             AnimationBuilder builder = provider.getAnimationBuilder(maid, state);
             if (builder != null) {
-                for (RawAnimation rawAnimation : builder.getRawAnimationList()) {
-                    if (rawAnimation.loopType == ILoopType.EDefaultLoopTypes.PLAY_ONCE) {
-                        event.getController().markNeedsReload();
-                        break;
-                    }
+                if (lastPhase == IMagicCastingState.CastingPhase.NONE) {
+                    controller.markNeedsReload();
                 }
-                event.getController().setAnimation(builder);
+                controller.setAnimation(builder);
+                return PlayState.CONTINUE;
+            }
+
+            // builder 为 null，但 phase 有效，继续播放当前动画
+            if (controller.getAnimationState() != com.github.tartaricacid.touhoulittlemaid.geckolib3.core.AnimationState.STOPPED) {
                 return PlayState.CONTINUE;
             }
         }
 
         // 没有任何附属提供有效的动画
+        geckoEntity.setLastCastingPhase(IMagicCastingState.CastingPhase.NONE);
+        controller.clearAnimationCache();
         return PlayState.STOP;
     }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/entity/GeckoMaidEntity.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/entity/GeckoMaidEntity.java
@@ -1,6 +1,7 @@
 package com.github.tartaricacid.touhoulittlemaid.client.entity;
 
 import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.api.animation.IMagicCastingState;
 import com.github.tartaricacid.touhoulittlemaid.api.entity.IMaid;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.HardcodedAnimationManger;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.gecko.AnimationManager;
@@ -43,6 +44,11 @@ public class GeckoMaidEntity<T extends Mob> extends AnimatableEntity<T> implemen
      * 沉浸式奏乐兼容数据缓存
      */
     private ImmersiveMelodiesCompat.ImmersiveMelodiesData imData = new ImmersiveMelodiesCompat.ImmersiveMelodiesData();
+
+    /**
+     * 上一次的魔法咏唱阶段，用于判断阶段过渡时的动画行为
+     */
+    private IMagicCastingState.CastingPhase lastCastingPhase = IMagicCastingState.CastingPhase.NONE;
 
     public GeckoMaidEntity(T mob, IMaid maid) {
         super(mob, FPS);
@@ -184,6 +190,14 @@ public class GeckoMaidEntity<T extends Mob> extends AnimatableEntity<T> implemen
 
     public ImmersiveMelodiesCompat.ImmersiveMelodiesData getImmersiveMelodiesData() {
         return imData;
+    }
+
+    public IMagicCastingState.CastingPhase getLastCastingPhase() {
+        return lastCastingPhase;
+    }
+
+    public void setLastCastingPhase(IMagicCastingState.CastingPhase phase) {
+        this.lastCastingPhase = phase;
     }
 
     private static class MaidState<T extends Mob> {

--- a/src/main/resources/assets/touhou_little_maid/animation/iss.animation.json
+++ b/src/main/resources/assets/touhou_little_maid/animation/iss.animation.json
@@ -715,6 +715,7 @@
 			}
 		},
 		"iss:long_cast": {
+			"loop": true,
 			"animation_length": 5,
 			"bones": {
 				"UpBody": {
@@ -976,6 +977,7 @@
 			}
 		},
 		"iss:continuous_overhead": {
+			"loop": true,
 			"animation_length": 0.88,
 			"bones": {
 				"UpBody": {
@@ -1676,6 +1678,7 @@
 			}
 		},
 		"iss:continuous_thrust": {
+			"loop": true,
 			"animation_length": 0.44,
 			"bones": {
 				"UpBody": {


### PR DESCRIPTION
修复魔法咏唱动画控制器逻辑，使魔法咏唱动画能够正确响应阶段变化、支持动画切换、以及正确处理瞬发/收尾动画的播放完整性。

重要说明

## 阶段过渡规则

| 前一个阶段 | 当前阶段 | 行为 |
|-----------|---------|------|
| `START` | `NONE` | 允许终止（咏唱被打断） |
| `CASTING` | `NONE` | 允许终止（咏唱被打断） |
| `INSTANT` | `NONE` | 继续播放（瞬发动画需要播完） |
| `END` | `NONE` | 继续播放（收尾动画需要播完） |

## 状态机流程图

```mermaid
stateDiagram-v2
    [*] --> NONE: 初始状态
    
    NONE --> INSTANT: 瞬间施法
    NONE --> START: 开始咏唱
    
    INSTANT --> NONE: 动画播放完毕
    
    START --> CASTING: 进入持续咏唱
    START --> NONE: 咏唱被打断（允许终止）
    
    CASTING --> END: 咏唱完成
    CASTING --> NONE: 咏唱被打断（允许终止）
    
    END --> NONE: 动画播放完毕
    
    note right of INSTANT: 过渡到 NONE 时<br/>继续播放直到动画结束
    note right of END: 过渡到 NONE 时<br/>继续播放直到动画结束
    note right of START: 过渡到 NONE 时<br/>允许立即终止
    note right of CASTING: 过渡到 NONE 时<br/>允许立即终止
```

简而言之就是最后一个步骤必须要把动画播放完