### PR TITLE
女仆手办破环方法错误导致的刷物品 #1006

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/block/BlockGarageKit.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/block/BlockGarageKit.java
@@ -73,7 +73,9 @@ public class BlockGarageKit extends Block implements EntityBlock {
 
     @Override
     public void onRemove(BlockState state, Level worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
-        popResource(worldIn, pos, getGarageKitFromWorld(worldIn, pos));
+        if(!isMoving){
+            popResource(worldIn, pos, getGarageKitFromWorld(worldIn, pos));
+        }
         super.onRemove(state, worldIn, pos, newState, isMoving);
     }
 


### PR DESCRIPTION

**问题原因：**
当`BlockGarageKit.java`的`onRemove`方法被触发，都会掉落手办物品：

```java
@Override
public void onRemove(BlockState state, Level worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
    popResource(worldIn, pos, getGarageKitFromWorld(worldIn, pos));  // 总是掉落物品
    super.onRemove(state, worldIn, pos, newState, isMoving);
}
```


**修复方案：**
```java
@Override
public void onRemove(BlockState state, Level worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
    if (!isMoving) {  // 只有在非移动状态下才掉落物品
        popResource(worldIn, pos, getGarageKitFromWorld(worldIn, pos));
    }
    super.onRemove(state, worldIn, pos, newState, isMoving);  // 调用父类清理方块实体
}
```


**修复效果：**
- `isMoving=false`（破坏/替换）：正常掉落手办物品
- `isMoving=true`（移动操作）：不掉落物品，只移动方块
