### PR TITLE
Curios 死亡掉落修复与 Curios 上的精妙背包交互

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/setting/papi/PapiReplacer.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/setting/papi/PapiReplacer.java
@@ -180,7 +180,7 @@ public class PapiReplacer {
 
     private static String getInventoryItems(EntityMaid maid, String chatLanguage) {
         List<String> names = Lists.newArrayList();
-        RangedWrapper backpack = maid.getAvailableBackpackInv();
+        var backpack = maid.getAvailableBackpackInv();
         for (int i = 0; i < backpack.getSlots(); i++) {
             ItemStack stack = backpack.getStackInSlot(i);
             if (!stack.isEmpty()) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/event/MaidRequestItemEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/event/MaidRequestItemEvent.java
@@ -3,6 +3,7 @@ package com.github.tartaricacid.touhoulittlemaid.api.event;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.eventbus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.function.Predicate;
 
@@ -10,11 +11,12 @@ import java.util.function.Predicate;
  * 当女仆需要从外部获取物品到自己物品栏时触发此事件。
  * 此事件可取消。如果取消，表示已处理完毕，不再继续传递给其他处理器。
  */
+@ApiStatus.AvailableSince("1.5.1")
 public class MaidRequestItemEvent extends Event {
-    private final EntityMaid           maid;
+    private final EntityMaid maid;
     private final Predicate<ItemStack> itemFilter;
-    private final int                  maxCount;
-    private       ItemStack            requestedItem = ItemStack.EMPTY;
+    private final int maxCount;
+    private ItemStack requestedItem = ItemStack.EMPTY;
 
     /**
      * @param maid       请求物品的女仆
@@ -22,9 +24,9 @@ public class MaidRequestItemEvent extends Event {
      * @param maxCount   最大请求数量
      */
     public MaidRequestItemEvent(EntityMaid maid, Predicate<ItemStack> itemFilter, int maxCount) {
-        this.maid       = maid;
+        this.maid = maid;
         this.itemFilter = itemFilter;
-        this.maxCount   = maxCount;
+        this.maxCount = maxCount;
     }
 
     public EntityMaid getMaid() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/event/MaidRequestItemEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/api/event/MaidRequestItemEvent.java
@@ -1,0 +1,61 @@
+package com.github.tartaricacid.touhoulittlemaid.api.event;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.function.Predicate;
+
+/**
+ * 当女仆需要从外部获取物品到自己物品栏时触发此事件。
+ * 此事件可取消。如果取消，表示已处理完毕，不再继续传递给其他处理器。
+ */
+public class MaidRequestItemEvent extends Event {
+    private final EntityMaid           maid;
+    private final Predicate<ItemStack> itemFilter;
+    private final int                  maxCount;
+    private       ItemStack            requestedItem = ItemStack.EMPTY;
+
+    /**
+     * @param maid       请求物品的女仆
+     * @param itemFilter 物品筛选条件
+     * @param maxCount   最大请求数量
+     */
+    public MaidRequestItemEvent(EntityMaid maid, Predicate<ItemStack> itemFilter, int maxCount) {
+        this.maid       = maid;
+        this.itemFilter = itemFilter;
+        this.maxCount   = maxCount;
+    }
+
+    public EntityMaid getMaid() {
+        return maid;
+    }
+
+    public Predicate<ItemStack> getItemFilter() {
+        return itemFilter;
+    }
+
+    public int getMaxCount() {
+        return maxCount;
+    }
+
+    /**
+     * 获取处理结果，即已成功转移到女仆物品栏的物品
+     */
+    public ItemStack getRequestedItem() {
+        return requestedItem;
+    }
+
+    public void setRequestedItem(ItemStack requestedItem) {
+        this.requestedItem = requestedItem;
+    }
+
+    public boolean hasRequestedItem() {
+        return !requestedItem.isEmpty();
+    }
+
+    @Override
+    public boolean isCancelable() {
+        return true;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosCompat.java
@@ -2,8 +2,6 @@ package com.github.tartaricacid.touhoulittlemaid.compat.curios;
 
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.client.CuriosContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.menu.CuriosContainer;
-import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
-import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.SBackpackCuriosCompat;
 import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.client.Minecraft;
@@ -19,8 +17,6 @@ public class CuriosCompat {
     public static void init() {
         IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new CuriosEvent());
-
-        if (SBackpackCompat.isLoaded()) SBackpackCuriosCompat.init();
     }
 
     public static boolean isLoaded() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosCompat.java
@@ -2,6 +2,8 @@ package com.github.tartaricacid.touhoulittlemaid.compat.curios;
 
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.client.CuriosContainerScreen;
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.menu.CuriosContainer;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.SBackpackCuriosCompat;
 import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.client.Minecraft;
@@ -17,6 +19,8 @@ public class CuriosCompat {
     public static void init() {
         IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new CuriosEvent());
+
+        if (SBackpackCompat.isLoaded()) SBackpackCuriosCompat.init();
     }
 
     public static boolean isLoaded() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosEvent.java
@@ -1,14 +1,21 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.curios;
 
 
+import com.github.tartaricacid.touhoulittlemaid.api.event.MaidTombstoneEvent;
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.menu.CuriosContainer;
+import com.github.tartaricacid.touhoulittlemaid.entity.item.EntityTombstone;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
+import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.event.SlotModifiersUpdatedEvent;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 public class CuriosEvent {
     /**
@@ -27,5 +34,28 @@ public class CuriosEvent {
                 }
             }
         }
+    }
+
+    /**
+     * 当女仆墓碑生成时，将 Curios 饰品从女仆身上转移到墓碑中
+     * Curios 后续的掉落事件仍然会触发，但此时女仆身上已经没有饰品了
+     */
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public void onMaidTombstone(MaidTombstoneEvent event) {
+        if (event.isCanceled()) return;
+        if (!CuriosCompat.isLoadedOrEnable()) return;
+        
+        EntityTombstone tombstone = event.getTombstone();
+        EntityMaid      maid      = event.getMaid();
+        
+        CuriosApi.getCuriosInventory(maid).ifPresent(handler -> {
+            for (ICurioStacksHandler stacksHandler : handler.getCurios().values()) {
+                IDynamicStackHandler stacks = stacksHandler.getStacks();
+                for (int i = 0; i < stacks.getSlots(); i++) {
+                    ItemStack stack = stacks.extractItem(i, stacks.getSlotLimit(i), false);
+                    if (!stack.isEmpty()) tombstone.insertItem(stack);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/curios/CuriosEvent.java
@@ -42,18 +42,25 @@ public class CuriosEvent {
      */
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public void onMaidTombstone(MaidTombstoneEvent event) {
-        if (event.isCanceled()) return;
-        if (!CuriosCompat.isLoadedOrEnable()) return;
-        
+        if (event.isCanceled()) {
+            return;
+        }
+        if (!CuriosCompat.isLoadedOrEnable()) {
+            return;
+        }
+
         EntityTombstone tombstone = event.getTombstone();
-        EntityMaid      maid      = event.getMaid();
-        
+        EntityMaid maid = event.getMaid();
+
         CuriosApi.getCuriosInventory(maid).ifPresent(handler -> {
-            for (ICurioStacksHandler stacksHandler : handler.getCurios().values()) {
+            var values = handler.getCurios().values();
+            for (ICurioStacksHandler stacksHandler : values) {
                 IDynamicStackHandler stacks = stacksHandler.getStacks();
                 for (int i = 0; i < stacks.getSlots(); i++) {
                     ItemStack stack = stacks.extractItem(i, stacks.getSlotLimit(i), false);
-                    if (!stack.isEmpty()) tombstone.insertItem(stack);
+                    if (!stack.isEmpty()) {
+                        tombstone.insertItem(stack);
+                    }
                 }
             }
         });

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/gun/tacz/TacInnerCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/gun/tacz/TacInnerCompat.java
@@ -2,6 +2,7 @@ package com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz;
 
 import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidInvWrapper;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.entity.IGunOperator;
@@ -128,12 +129,11 @@ public class TacInnerCompat {
 
         if (result == ShootResult.NO_AMMO) {
             // reload 不会触发 MaidRequestItemEvent，此处手动请求弹药
-            ItemsUtil.findStackSlot(
-                shooter.getAvailableInv(true),
-                stack -> {
-                    IAmmo ammo = IAmmo.getIAmmoOrNull(stack);
-                    return ammo != null && ammo.isAmmoOfGun(gunItem, stack);
-                });
+            MaidInvWrapper availableInv = shooter.getAvailableInv(true);
+            ItemsUtil.findStackSlot(availableInv, stack -> {
+                IAmmo ammo = IAmmo.getIAmmoOrNull(stack);
+                return ammo != null && ammo.isAmmoOfGun(gunItem, stack);
+            });
             gunOperator.reload();
             float emptyTime = gunData.getReloadData().getCooldown().getEmptyTime();
             return Math.round(emptyTime * 20) + 2;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/gun/tacz/TacInnerCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/gun/tacz/TacInnerCompat.java
@@ -2,10 +2,12 @@ package com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz;
 
 import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.tacz.guns.api.TimelessAPI;
 import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.entity.ShootResult;
 import com.tacz.guns.api.item.GunTabType;
+import com.tacz.guns.api.item.IAmmo;
 import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.resource.index.CommonGunIndex;
@@ -125,6 +127,13 @@ public class TacInnerCompat {
         }
 
         if (result == ShootResult.NO_AMMO) {
+            // reload 不会触发 MaidRequestItemEvent，此处手动请求弹药
+            ItemsUtil.findStackSlot(
+                shooter.getAvailableInv(true),
+                stack -> {
+                    IAmmo ammo = IAmmo.getIAmmoOrNull(stack);
+                    return ammo != null && ammo.isAmmoOfGun(gunItem, stack);
+                });
             gunOperator.reload();
             float emptyTime = gunData.getReloadData().getCooldown().getEmptyTime();
             return Math.round(emptyTime * 20) + 2;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompat.java
@@ -1,10 +1,10 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack;
 
-import com.github.tartaricacid.touhoulittlemaid.compat.curios.CuriosCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.SBackpackCuriosCompat;
+import com.github.tartaricacid.touhoulittlemaid.init.registry.CompatRegistry;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
-import net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackItem;
+import net.minecraftforge.fml.ModList;
 
 public class SBackpackCompat {
     private static boolean IS_LOADED = false;
@@ -12,8 +12,10 @@ public class SBackpackCompat {
     public static void init() {
         IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new BackpackRightClickMaidEvent());
-        
-        if (CuriosCompat.isLoaded()) SBackpackCuriosCompat.init();
+        // 女仆与精妙背包的 Curios 兼容
+        if (ModList.get().isLoaded(CompatRegistry.CURIOS)) {
+            SBackpackCuriosCompat.init();
+        }
     }
 
     public static boolean isLoaded() {
@@ -21,7 +23,9 @@ public class SBackpackCompat {
     }
 
     public static boolean isBackpack(ItemStack stack) {
-        if (stack.isEmpty()) return false;
-        return stack.getItem() instanceof BackpackItem;
+        if (isLoaded()) {
+            return SBackpackCompatInner.isBackpack(stack);
+        }
+        return false;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompat.java
@@ -1,9 +1,27 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.curios.CuriosCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.SBackpackCuriosCompat;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
+import net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackItem;
 
 public class SBackpackCompat {
+    private static boolean IS_LOADED = false;
+
     public static void init() {
+        IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new BackpackRightClickMaidEvent());
+        
+        if (CuriosCompat.isLoaded()) SBackpackCuriosCompat.init();
+    }
+
+    public static boolean isLoaded() {
+        return IS_LOADED;
+    }
+
+    public static boolean isBackpack(ItemStack stack) {
+        if (stack.isEmpty()) return false;
+        return stack.getItem() instanceof BackpackItem;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompatInner.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/SBackpackCompatInner.java
@@ -1,0 +1,10 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack;
+
+import net.minecraft.world.item.ItemStack;
+import net.p3pp3rf1y.sophisticatedbackpacks.backpack.BackpackItem;
+
+public class SBackpackCompatInner {
+    static boolean isBackpack(ItemStack stack) {
+        return stack.getItem() instanceof BackpackItem;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackCuriosEquipEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackCuriosEquipEventHandler.java
@@ -10,7 +10,9 @@ public class BackpackCuriosEquipEventHandler {
 
     @SubscribeEvent
     public void onCurioChange(CurioChangeEvent event) {
-        if (!(event.getEntity() instanceof EntityMaid maid)) return;
+        if (!(event.getEntity() instanceof EntityMaid maid)) {
+            return;
+        }
 
         ItemStack from = event.getFrom();
         ItemStack to = event.getTo();
@@ -20,8 +22,12 @@ public class BackpackCuriosEquipEventHandler {
         boolean wasBackpack = SBackpackCompat.isBackpack(from);
         boolean isBackpack = SBackpackCompat.isBackpack(to);
 
-        if (wasBackpack && !isBackpack) MaidBackpackCache.onUnequipped(maid, slotType, slotIndex);
-        else if (!wasBackpack && isBackpack) MaidBackpackCache.onEquipped(maid, slotType, slotIndex);
+        if (wasBackpack && !isBackpack) {
+            MaidBackpackCache.onUnequipped(maid, slotType, slotIndex);
+        } else if (!wasBackpack && isBackpack) {
+            MaidBackpackCache.onEquipped(maid, slotType, slotIndex);
+        }
+
         // 如果背包被替换为另一个背包，槽位引用不变，不需要更新
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackCuriosEquipEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackCuriosEquipEventHandler.java
@@ -1,0 +1,27 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import top.theillusivec4.curios.api.event.CurioChangeEvent;
+
+public class BackpackCuriosEquipEventHandler {
+
+    @SubscribeEvent
+    public void onCurioChange(CurioChangeEvent event) {
+        if (!(event.getEntity() instanceof EntityMaid maid)) return;
+
+        ItemStack from = event.getFrom();
+        ItemStack to = event.getTo();
+        String slotType = event.getIdentifier();
+        int slotIndex = event.getSlotIndex();
+
+        boolean wasBackpack = SBackpackCompat.isBackpack(from);
+        boolean isBackpack = SBackpackCompat.isBackpack(to);
+
+        if (wasBackpack && !isBackpack) MaidBackpackCache.onUnequipped(maid, slotType, slotIndex);
+        else if (!wasBackpack && isBackpack) MaidBackpackCache.onEquipped(maid, slotType, slotIndex);
+        // 如果背包被替换为另一个背包，槽位引用不变，不需要更新
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackPickupEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackPickupEventHandler.java
@@ -1,79 +1,91 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
 
 import com.github.tartaricacid.touhoulittlemaid.api.event.MaidPickupEvent;
-import com.github.tartaricacid.touhoulittlemaid.api.event.MaidPlaySoundEvent;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
-import com.github.tartaricacid.touhoulittlemaid.init.InitSounds;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
-import java.util.List;
-
 /**
  * 允许女仆在拾取物品时放入 Curios 槽位中的背包
- * 
+ * <p>
  * 拾取优先级：
  * 1. 优先放入已有相同物品的容器（物品栏 > back背包 > 其他背包，按优先级排序）
  * 2. 如果没有已有该物品的容器能放下，则按默认顺序依次尝试
  */
 public class BackpackPickupEventHandler {
-
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onMaidPickupPre(MaidPickupEvent.ItemResultPre event) {
         EntityMaid maid = event.getMaid();
         ItemEntity itemEntity = event.getEntityItem();
         boolean simulate = event.isSimulate();
 
-        if (!tryPickup(maid, itemEntity, simulate)) return;
-        
+        if (!tryPickup(maid, itemEntity, simulate)) {
+            return;
+        }
+
         event.setCanPickup(true);
         event.setCanceled(true);
     }
 
     private boolean tryPickup(EntityMaid maid, ItemEntity itemEntity, boolean simulate) {
-        if (maid.level().isClientSide) return false;
-        if (!itemEntity.isAlive()) return false;
-        if (itemEntity.hasPickUpDelay()) return false;
-
-        ItemStack itemstack = itemEntity.getItem();
-        if (!EntityMaid.canInsertItem(itemstack)) return false;
-
-        int oriCnt = itemstack.getCount();
-        List<MaidBackpackCache.ContainerRef> containers = MaidBackpackCache.getContainers(maid);
-
-        for (MaidBackpackCache.ContainerRef container : containers) {
-            if (!container.containing(itemstack)) continue;
-
-            itemstack = container.insert(itemstack, simulate);
-            if (itemstack.isEmpty()) break;
+        if (maid.level.isClientSide || !itemEntity.isAlive() || itemEntity.hasPickUpDelay()) {
+            return false;
+        }
+        ItemStack itemStack = itemEntity.getItem();
+        if (!EntityMaid.canInsertItem(itemStack)) {
+            return false;
         }
 
-        if (!itemstack.isEmpty())
-            for (MaidBackpackCache.ContainerRef container : containers)
-            {
-                itemstack = container.insert(itemstack, simulate);
-                if (itemstack.isEmpty()) break;
-            }
+        int originCount = itemStack.getCount();
+        var containers = MaidBackpackCache.getContainers(maid);
 
-        if (oriCnt == itemstack.getCount()) return false;
-        if (!simulate) handlePickupEffects(maid, itemEntity, itemstack, oriCnt);
+        // 先尝试放入已有相同物品的容器
+        for (var container : containers) {
+            if (!container.containing(itemStack)) {
+                continue;
+            }
+            itemStack = container.insert(itemStack, simulate);
+            if (itemStack.isEmpty()) {
+                break;
+            }
+        }
+
+        // 如果还有剩余，再按默认顺序尝试放入
+        if (!itemStack.isEmpty()) {
+            for (var container : containers) {
+                itemStack = container.insert(itemStack, simulate);
+                if (itemStack.isEmpty()) {
+                    break;
+                }
+            }
+        }
+
+        if (originCount == itemStack.getCount()) {
+            return false;
+        }
+        if (!simulate) {
+            // 最后触发拾取动画和音效，更新实体物品数量
+            // 以及触发 MaidPickupEvent.ItemResultPost 事件
+            handlePickupEffects(maid, itemEntity, itemStack, originCount);
+        }
         return true;
     }
 
-    private void handlePickupEffects(EntityMaid maid, ItemEntity itemEntity, ItemStack remaining, int oriCnt) {
-        int pickedCount = oriCnt - remaining.getCount();
+    private void handlePickupEffects(EntityMaid maid, ItemEntity itemEntity, ItemStack remaining, int originCount) {
+        int pickedCount = originCount - remaining.getCount();
         maid.take(itemEntity, pickedCount);
-
-        if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(maid)))
-            maid.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
+        maid.tryPlayMaidPickupSound();
 
         ItemStack pickedStack = new ItemStack(itemEntity.getItem().getItem(), pickedCount);
         MinecraftForge.EVENT_BUS.post(new MaidPickupEvent.ItemResultPost(maid, pickedStack));
 
-        if (remaining.isEmpty()) itemEntity.discard();
-        else itemEntity.setItem(remaining);
+        if (remaining.isEmpty()) {
+            itemEntity.discard();
+        } else {
+            itemEntity.setItem(remaining);
+        }
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackPickupEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackPickupEventHandler.java
@@ -1,0 +1,79 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
+
+import com.github.tartaricacid.touhoulittlemaid.api.event.MaidPickupEvent;
+import com.github.tartaricacid.touhoulittlemaid.api.event.MaidPlaySoundEvent;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.init.InitSounds;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.List;
+
+/**
+ * 允许女仆在拾取物品时放入 Curios 槽位中的背包
+ * 
+ * 拾取优先级：
+ * 1. 优先放入已有相同物品的容器（物品栏 > back背包 > 其他背包，按优先级排序）
+ * 2. 如果没有已有该物品的容器能放下，则按默认顺序依次尝试
+ */
+public class BackpackPickupEventHandler {
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void onMaidPickupPre(MaidPickupEvent.ItemResultPre event) {
+        EntityMaid maid = event.getMaid();
+        ItemEntity itemEntity = event.getEntityItem();
+        boolean simulate = event.isSimulate();
+
+        if (!tryPickup(maid, itemEntity, simulate)) return;
+        
+        event.setCanPickup(true);
+        event.setCanceled(true);
+    }
+
+    private boolean tryPickup(EntityMaid maid, ItemEntity itemEntity, boolean simulate) {
+        if (maid.level().isClientSide) return false;
+        if (!itemEntity.isAlive()) return false;
+        if (itemEntity.hasPickUpDelay()) return false;
+
+        ItemStack itemstack = itemEntity.getItem();
+        if (!EntityMaid.canInsertItem(itemstack)) return false;
+
+        int oriCnt = itemstack.getCount();
+        List<MaidBackpackCache.ContainerRef> containers = MaidBackpackCache.getContainers(maid);
+
+        for (MaidBackpackCache.ContainerRef container : containers) {
+            if (!container.containing(itemstack)) continue;
+
+            itemstack = container.insert(itemstack, simulate);
+            if (itemstack.isEmpty()) break;
+        }
+
+        if (!itemstack.isEmpty())
+            for (MaidBackpackCache.ContainerRef container : containers)
+            {
+                itemstack = container.insert(itemstack, simulate);
+                if (itemstack.isEmpty()) break;
+            }
+
+        if (oriCnt == itemstack.getCount()) return false;
+        if (!simulate) handlePickupEffects(maid, itemEntity, itemstack, oriCnt);
+        return true;
+    }
+
+    private void handlePickupEffects(EntityMaid maid, ItemEntity itemEntity, ItemStack remaining, int oriCnt) {
+        int pickedCount = oriCnt - remaining.getCount();
+        maid.take(itemEntity, pickedCount);
+
+        if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(maid)))
+            maid.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
+
+        ItemStack pickedStack = new ItemStack(itemEntity.getItem().getItem(), pickedCount);
+        MinecraftForge.EVENT_BUS.post(new MaidPickupEvent.ItemResultPost(maid, pickedStack));
+
+        if (remaining.isEmpty()) itemEntity.discard();
+        else itemEntity.setItem(remaining);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackRequestItemEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackRequestItemEventHandler.java
@@ -1,0 +1,150 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
+
+import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
+import com.github.tartaricacid.touhoulittlemaid.api.event.MaidRequestItemEvent;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidBackpackHandler;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.wrapper.RangedWrapper;
+import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class BackpackRequestItemEventHandler {
+
+    @SubscribeEvent
+    public void onMaidRequestItem(MaidRequestItemEvent event) {
+        EntityMaid           maid   = event.getMaid();
+        Predicate<ItemStack> filter = event.getItemFilter();
+        int                  maxCnt = event.getMaxCount();
+
+        List<MaidBackpackCache.ContainerRef> containers = MaidBackpackCache.getContainers(maid);
+        if (containers.size() <= 1) return;
+
+        for (int i = 1; i < containers.size(); i++) {
+            MaidBackpackCache.ContainerRef ref = containers.get(i);
+            if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+
+            ItemStack extracted = extractItemsFromBackpack(backpackRef, filter, maxCnt);
+            if (extracted.isEmpty()) continue;
+
+            ItemStack remaining = transferToMaidInv(maid, extracted);
+            if (remaining.getCount() == extracted.getCount())
+                if (transferToBackpack(maid, containers))
+                    remaining = transferToMaidInv(maid, extracted);
+
+            if (remaining.getCount() < extracted.getCount()) {
+                int insertedCount = extracted.getCount() - remaining.getCount();
+                ItemStack result = extracted.copyWithCount(insertedCount);
+
+                if (!remaining.isEmpty()) backpackRef.insert(remaining, false);
+
+                event.setRequestedItem(result);
+                event.setCanceled(true);
+                return;
+            } else backpackRef.insert(extracted, false);
+        }
+    }
+
+    /**
+     * 尝试从背包中提取符合条件的物品
+     *
+     * @param backpackRef 背包引用
+     * @param filter      物品筛选条件
+     * @param maxCount    最大提取数量，-1 表示自动根据物品堆叠上限确定
+     * @return 提取的物品，如果没找到则返回 {@link ItemStack#EMPTY}
+     */
+    private ItemStack extractItemsFromBackpack(MaidBackpackCache.BackpackSlotRef backpackRef,
+                                              Predicate<ItemStack> filter, int maxCount) {
+        ItemStack backpackStack = backpackRef.getBackpackStack();
+        if (backpackStack.isEmpty()) return ItemStack.EMPTY;
+
+        return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
+                .map(wrapper -> {
+                    ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+
+                    for (int slot = 0; slot < inv.getSlots(); slot++) {
+                        ItemStack stackInSlot = inv.getStackInSlot(slot);
+                        if (stackInSlot.isEmpty() || !filter.test(stackInSlot)) continue;
+
+                        int itemMaxStack = stackInSlot.getMaxStackSize();
+                        int effectiveMaxCount = (maxCount == -1) 
+                                ? itemMaxStack 
+                                : Math.min(maxCount, itemMaxStack);
+                        int extractCount = Math.min(effectiveMaxCount, stackInSlot.getCount());
+                        ItemStack extracted = inv.extractItem(slot, extractCount, false);
+                        return extracted;
+                    }
+                    return ItemStack.EMPTY;
+                })
+                .orElse(ItemStack.EMPTY);
+    }
+
+    private ItemStack transferToMaidInv(EntityMaid maid, ItemStack stack) {
+        IItemHandler inv = maid.getAvailableInv(false);
+        return ItemHandlerHelper.insertItemStacked(inv, stack, false);
+    }
+
+    /**
+     * 尝试将物品栏中的物品放入背包以腾出空间
+     * 会跳过装饰槽位 {@link MaidBackpackHandler#BACKPACK_ITEM_SLOT}
+     * 该槽位物品永远不会被尝试放入背包
+     */
+    private boolean transferToBackpack(EntityMaid maid, List<MaidBackpackCache.ContainerRef> containers) {
+        RangedWrapper inv = maid.getAvailableBackpackInv();
+        
+        int targetSlot = -1;
+        ItemStack targetStack = ItemStack.EMPTY;
+        for (int i = inv.getSlots() - 1; i >= 0; i--) {
+            if (i == MaidBackpackHandler.BACKPACK_ITEM_SLOT) continue;
+            ItemStack stack = inv.getStackInSlot(i);
+            if (stack.isEmpty()) continue;
+            targetSlot = i;
+            targetStack = stack;
+            break;
+        }
+        
+        if (targetSlot < 0 || targetStack.isEmpty()) return false;
+
+        // 尝试将该物品放入背包
+        // 优先放到已有该物品的背包中，但排除物品栏自身（从索引1开始）
+        ItemStack remaining = targetStack.copy();
+        final int slotToEmpty = targetSlot;
+        final ItemStack originalStack = targetStack;
+
+        for (int i = 1; i < containers.size(); i++) {
+            MaidBackpackCache.ContainerRef ref = containers.get(i);
+            if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+
+            if (!backpackRef.containing(remaining)) continue;
+            remaining = backpackRef.insert(remaining, false);
+            if (remaining.isEmpty()) break;
+        }
+
+        if (!remaining.isEmpty()) {
+            for (int i = 1; i < containers.size(); i++) {
+                MaidBackpackCache.ContainerRef ref = containers.get(i);
+                if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+
+                remaining = backpackRef.insert(remaining, false);
+                if (remaining.isEmpty()) break;
+            }
+        }
+
+        if (remaining.getCount() < originalStack.getCount()) {
+            if (remaining.isEmpty()) inv.extractItem(slotToEmpty, originalStack.getCount(), false);
+            else inv.extractItem(slotToEmpty, originalStack.getCount() - remaining.getCount(), false);
+
+            return inv.getStackInSlot(slotToEmpty).isEmpty() ||
+                   inv.getStackInSlot(slotToEmpty).getCount() < inv.getStackInSlot(slotToEmpty).getMaxStackSize();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackRequestItemEventHandler.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/BackpackRequestItemEventHandler.java
@@ -1,54 +1,66 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
 
-import com.github.tartaricacid.touhoulittlemaid.TouhouLittleMaid;
 import com.github.tartaricacid.touhoulittlemaid.api.event.MaidRequestItemEvent;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref.BackpackSlotRef;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref.ContainerRef;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidBackpackHandler;
-import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
-import net.minecraftforge.items.wrapper.RangedWrapper;
 import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
+import net.p3pp3rf1y.sophisticatedbackpacks.backpack.wrapper.IBackpackWrapper;
 import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
 
 import java.util.List;
 import java.util.function.Predicate;
 
 public class BackpackRequestItemEventHandler {
-
     @SubscribeEvent
     public void onMaidRequestItem(MaidRequestItemEvent event) {
-        EntityMaid           maid   = event.getMaid();
+        EntityMaid maid = event.getMaid();
         Predicate<ItemStack> filter = event.getItemFilter();
-        int                  maxCnt = event.getMaxCount();
+        int maxCount = event.getMaxCount();
 
-        List<MaidBackpackCache.ContainerRef> containers = MaidBackpackCache.getContainers(maid);
-        if (containers.size() <= 1) return;
+        var containers = MaidBackpackCache.getContainers(maid);
+        if (containers.size() <= 1) {
+            return;
+        }
 
         for (int i = 1; i < containers.size(); i++) {
-            MaidBackpackCache.ContainerRef ref = containers.get(i);
-            if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+            ContainerRef ref = containers.get(i);
+            if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                continue;
+            }
 
-            ItemStack extracted = extractItemsFromBackpack(backpackRef, filter, maxCnt);
-            if (extracted.isEmpty()) continue;
+            ItemStack extracted = extractItemsFromBackpack(backpackRef, filter, maxCount);
+            if (extracted.isEmpty()) {
+                continue;
+            }
 
             ItemStack remaining = transferToMaidInv(maid, extracted);
-            if (remaining.getCount() == extracted.getCount())
-                if (transferToBackpack(maid, containers))
+            if (remaining.getCount() == extracted.getCount()) {
+                if (transferToBackpack(maid, containers)) {
                     remaining = transferToMaidInv(maid, extracted);
+                }
+            }
 
             if (remaining.getCount() < extracted.getCount()) {
                 int insertedCount = extracted.getCount() - remaining.getCount();
                 ItemStack result = extracted.copyWithCount(insertedCount);
 
-                if (!remaining.isEmpty()) backpackRef.insert(remaining, false);
+                if (!remaining.isEmpty()) {
+                    backpackRef.insert(remaining, false);
+                }
 
                 event.setRequestedItem(result);
                 event.setCanceled(true);
                 return;
-            } else backpackRef.insert(extracted, false);
+            } else {
+                backpackRef.insert(extracted, false);
+            }
         }
     }
 
@@ -60,30 +72,34 @@ public class BackpackRequestItemEventHandler {
      * @param maxCount    最大提取数量，-1 表示自动根据物品堆叠上限确定
      * @return 提取的物品，如果没找到则返回 {@link ItemStack#EMPTY}
      */
-    private ItemStack extractItemsFromBackpack(MaidBackpackCache.BackpackSlotRef backpackRef,
-                                              Predicate<ItemStack> filter, int maxCount) {
+    private ItemStack extractItemsFromBackpack(BackpackSlotRef backpackRef,
+                                               Predicate<ItemStack> filter, int maxCount) {
         ItemStack backpackStack = backpackRef.getBackpackStack();
-        if (backpackStack.isEmpty()) return ItemStack.EMPTY;
+        if (backpackStack.isEmpty()) {
+            return ItemStack.EMPTY;
+        }
 
-        return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
-                .map(wrapper -> {
-                    ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+        Capability<IBackpackWrapper> instance = CapabilityBackpackWrapper.getCapabilityInstance();
+        var capability = backpackStack.getCapability(instance);
 
-                    for (int slot = 0; slot < inv.getSlots(); slot++) {
-                        ItemStack stackInSlot = inv.getStackInSlot(slot);
-                        if (stackInSlot.isEmpty() || !filter.test(stackInSlot)) continue;
+        return capability.map(wrapper -> {
+            ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
 
-                        int itemMaxStack = stackInSlot.getMaxStackSize();
-                        int effectiveMaxCount = (maxCount == -1) 
-                                ? itemMaxStack 
-                                : Math.min(maxCount, itemMaxStack);
-                        int extractCount = Math.min(effectiveMaxCount, stackInSlot.getCount());
-                        ItemStack extracted = inv.extractItem(slot, extractCount, false);
-                        return extracted;
-                    }
-                    return ItemStack.EMPTY;
-                })
-                .orElse(ItemStack.EMPTY);
+            for (int slot = 0; slot < inv.getSlots(); slot++) {
+                ItemStack stackInSlot = inv.getStackInSlot(slot);
+                if (stackInSlot.isEmpty() || !filter.test(stackInSlot)) {
+                    continue;
+                }
+
+                int itemMaxStack = stackInSlot.getMaxStackSize();
+                int effectiveMaxCount = (maxCount == -1)
+                        ? itemMaxStack
+                        : Math.min(maxCount, itemMaxStack);
+                int extractCount = Math.min(effectiveMaxCount, stackInSlot.getCount());
+                return inv.extractItem(slot, extractCount, false);
+            }
+            return ItemStack.EMPTY;
+        }).orElse(ItemStack.EMPTY);
     }
 
     private ItemStack transferToMaidInv(EntityMaid maid, ItemStack stack) {
@@ -96,53 +112,72 @@ public class BackpackRequestItemEventHandler {
      * 会跳过装饰槽位 {@link MaidBackpackHandler#BACKPACK_ITEM_SLOT}
      * 该槽位物品永远不会被尝试放入背包
      */
-    private boolean transferToBackpack(EntityMaid maid, List<MaidBackpackCache.ContainerRef> containers) {
-        RangedWrapper inv = maid.getAvailableBackpackInv();
-        
+    private boolean transferToBackpack(EntityMaid maid, List<ContainerRef> containers) {
+        var inv = maid.getAvailableBackpackInv();
+
         int targetSlot = -1;
         ItemStack targetStack = ItemStack.EMPTY;
         for (int i = inv.getSlots() - 1; i >= 0; i--) {
-            if (i == MaidBackpackHandler.BACKPACK_ITEM_SLOT) continue;
+            if (i == MaidBackpackHandler.BACKPACK_ITEM_SLOT) {
+                continue;
+            }
             ItemStack stack = inv.getStackInSlot(i);
-            if (stack.isEmpty()) continue;
+            if (stack.isEmpty()) {
+                continue;
+            }
             targetSlot = i;
             targetStack = stack;
             break;
         }
-        
-        if (targetSlot < 0 || targetStack.isEmpty()) return false;
+
+        if (targetSlot < 0 || targetStack.isEmpty()) {
+            return false;
+        }
 
         // 尝试将该物品放入背包
         // 优先放到已有该物品的背包中，但排除物品栏自身（从索引1开始）
         ItemStack remaining = targetStack.copy();
         final int slotToEmpty = targetSlot;
-        final ItemStack originalStack = targetStack;
+        final ItemStack originStack = targetStack;
 
         for (int i = 1; i < containers.size(); i++) {
-            MaidBackpackCache.ContainerRef ref = containers.get(i);
-            if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+            ContainerRef ref = containers.get(i);
+            if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                continue;
+            }
 
-            if (!backpackRef.containing(remaining)) continue;
+            if (!backpackRef.containing(remaining)) {
+                continue;
+            }
             remaining = backpackRef.insert(remaining, false);
-            if (remaining.isEmpty()) break;
+            if (remaining.isEmpty()) {
+                break;
+            }
         }
 
         if (!remaining.isEmpty()) {
             for (int i = 1; i < containers.size(); i++) {
-                MaidBackpackCache.ContainerRef ref = containers.get(i);
-                if (!(ref instanceof MaidBackpackCache.BackpackSlotRef backpackRef)) continue;
+                ContainerRef ref = containers.get(i);
+                if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                    continue;
+                }
 
                 remaining = backpackRef.insert(remaining, false);
-                if (remaining.isEmpty()) break;
+                if (remaining.isEmpty()) {
+                    break;
+                }
             }
         }
 
-        if (remaining.getCount() < originalStack.getCount()) {
-            if (remaining.isEmpty()) inv.extractItem(slotToEmpty, originalStack.getCount(), false);
-            else inv.extractItem(slotToEmpty, originalStack.getCount() - remaining.getCount(), false);
+        if (remaining.getCount() < originStack.getCount()) {
+            if (remaining.isEmpty()) {
+                inv.extractItem(slotToEmpty, originStack.getCount(), false);
+            } else {
+                inv.extractItem(slotToEmpty, originStack.getCount() - remaining.getCount(), false);
+            }
 
-            return inv.getStackInSlot(slotToEmpty).isEmpty() ||
-                   inv.getStackInSlot(slotToEmpty).getCount() < inv.getStackInSlot(slotToEmpty).getMaxStackSize();
+            ItemStack stack = inv.getStackInSlot(slotToEmpty);
+            return stack.isEmpty() || stack.getCount() < stack.getMaxStackSize();
         }
 
         return false;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
@@ -2,20 +2,17 @@ package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
 
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.CuriosCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref.BackpackSlotRef;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref.ContainerRef;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref.MaidInventoryRef;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.google.common.collect.Lists;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemHandlerHelper;
-import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
-import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
-import net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.WeakHashMap;
 
 /**
@@ -25,100 +22,6 @@ import java.util.WeakHashMap;
  */
 public class MaidBackpackCache {
     private static final WeakHashMap<EntityMaid, List<ContainerRef>> CACHE = new WeakHashMap<>();
-
-    public static abstract class ContainerRef {
-        public abstract boolean containing(ItemStack itemToCheck);
-        public abstract ItemStack insert(ItemStack itemstack, boolean simulate);
-    }
-
-    public static class MaidInventoryRef extends ContainerRef {
-        private final EntityMaid maid;
-
-        public MaidInventoryRef(EntityMaid maid) {
-            this.maid = maid;
-        }
-
-        @Override
-        public boolean containing(ItemStack itemToCheck) {
-            // EntityMaid 里就没找着 O(1) 的方法，遂遍历
-            IItemHandler inv = maid.getAvailableInv(false);
-            for (int i = 0; i < inv.getSlots(); i++) {
-                ItemStack stackInSlot = inv.getStackInSlot(i);
-                if (stackInSlot.isEmpty()) continue;
-                if (ItemStack.isSameItemSameTags(stackInSlot, itemToCheck)) return true;
-            }
-            return false;
-        }
-
-        @Override
-        public ItemStack insert(ItemStack itemstack, boolean simulate) {
-            return ItemHandlerHelper.insertItemStacked(maid.getAvailableInv(false), itemstack, simulate);
-        }
-    }
-
-    public static class BackpackSlotRef extends ContainerRef {
-        public final String slotType;
-        public final int slotIndex;
-        public final int priority;
-        private final EntityMaid maid;
-
-        public BackpackSlotRef(EntityMaid maid, String slotType, int slotIndex) {
-            this.maid = maid;
-            this.slotType = slotType;
-            this.slotIndex = slotIndex;
-            this.priority = SBackpackCuriosCompat.getSlotPriority(slotType);
-        }
-
-        public ItemStack getBackpackStack() {
-            return CuriosApi.getCuriosInventory(maid)
-                    .map(handler -> handler.getStacksHandler(slotType)
-                            .map(stacksHandler -> {
-                                IDynamicStackHandler stacks = stacksHandler.getStacks();
-                                if (slotIndex >= stacks.getSlots()) return ItemStack.EMPTY;
-                                
-                                ItemStack stack = stacks.getStackInSlot(slotIndex);
-                                if (SBackpackCompat.isBackpack(stack)) return stack;
-
-                                return ItemStack.EMPTY;
-                            })
-                            .orElse(ItemStack.EMPTY))
-                    .orElse(ItemStack.EMPTY);
-        }
-
-        @Override
-        public boolean containing(ItemStack itemToCheck) {
-            ItemStack backpackStack = getBackpackStack();
-            if (backpackStack.isEmpty()) return false;
-
-            return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
-                    .map(wrapper -> {
-                        ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
-                        Set<ItemStackKey> trackedStacks = inv.getTrackedStacks();
-                        return trackedStacks.stream()
-                                .anyMatch(key -> ItemStack.isSameItemSameTags(key.getStack(), itemToCheck));
-                    })
-                    .orElse(false);
-        }
-
-        @Override
-        public ItemStack insert(ItemStack itemstack, boolean simulate) {
-            ItemStack backpackStack = getBackpackStack();
-            if (backpackStack.isEmpty()) return itemstack;
-
-            return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
-                    .map(wrapper -> {
-                        ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
-                        return ItemHandlerHelper.insertItemStacked(inv, itemstack, simulate);
-                    })
-                    .orElse(itemstack);
-        }
-
-        public int compareTo(BackpackSlotRef other) {
-            int priCmp = Integer.compare(this.priority, other.priority);
-            if (priCmp != 0) return priCmp;
-            return Integer.compare(this.slotIndex, other.slotIndex);
-        }
-    }
 
     public static List<ContainerRef> getContainers(EntityMaid maid) {
         List<ContainerRef> containers = CACHE.get(maid);
@@ -131,13 +34,19 @@ public class MaidBackpackCache {
 
     public static void onEquipped(EntityMaid maid, String slotType, int slotIndex) {
         List<ContainerRef> containers = getContainers(maid);
-        BackpackSlotRef    newRef     = new BackpackSlotRef(maid, slotType, slotIndex);
+        BackpackSlotRef newRef = new BackpackSlotRef(maid, slotType, slotIndex);
 
         for (int i = 1; i < containers.size(); i++) {
             ContainerRef ref = containers.get(i);
-            if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
-            if (!backpackRef.slotType.equals(slotType)) continue;
-            if (backpackRef.slotIndex != slotIndex) continue;
+            if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                continue;
+            }
+            if (!backpackRef.slotType.equals(slotType)) {
+                continue;
+            }
+            if (backpackRef.slotIndex != slotIndex) {
+                continue;
+            }
             // 槽位类型与槽位索引均相同，无需处理
             return;
         }
@@ -145,8 +54,12 @@ public class MaidBackpackCache {
         int insertIndex = containers.size();
         for (int i = 1; i < containers.size(); i++) {
             ContainerRef ref = containers.get(i);
-            if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
-            if (newRef.compareTo(backpackRef) >= 0) continue;
+            if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                continue;
+            }
+            if (newRef.compareTo(backpackRef) >= 0) {
+                continue;
+            }
             insertIndex = i;
             break;
         }
@@ -155,10 +68,10 @@ public class MaidBackpackCache {
 
     public static void onUnequipped(EntityMaid maid, String slotType, int slotIndex) {
         List<ContainerRef> containers = getContainers(maid);
-
         containers.removeIf(ref -> {
-            if (ref instanceof BackpackSlotRef backpackRef)
+            if (ref instanceof BackpackSlotRef backpackRef) {
                 return backpackRef.slotType.equals(slotType) && backpackRef.slotIndex == slotIndex;
+            }
             return false;
         });
     }
@@ -168,12 +81,14 @@ public class MaidBackpackCache {
     }
 
     private static List<ContainerRef> buildContainerRefs(EntityMaid maid) {
-        List<ContainerRef> containers = new ArrayList<>();
+        List<ContainerRef> containers = Lists.newArrayList();
 
         containers.add(new MaidInventoryRef(maid));
-        if (!CuriosCompat.isLoadedOrEnable()) return containers;
+        if (!CuriosCompat.isLoadedOrEnable()) {
+            return containers;
+        }
 
-        List<BackpackSlotRef> backpackRefs = new ArrayList<>();
+        List<BackpackSlotRef> backpackRefs = Lists.newArrayList();
         CuriosApi.getCuriosInventory(maid).ifPresent(handler -> {
             for (var entry : handler.getCurios().entrySet()) {
                 String slotType = entry.getKey();
@@ -182,7 +97,9 @@ public class MaidBackpackCache {
 
                 for (int i = 0; i < stacks.getSlots(); i++) {
                     ItemStack stack = stacks.getStackInSlot(i);
-                    if (!SBackpackCompat.isBackpack(stack)) continue;
+                    if (!SBackpackCompat.isBackpack(stack)) {
+                        continue;
+                    }
                     backpackRefs.add(new BackpackSlotRef(maid, slotType, i));
                 }
             }
@@ -192,8 +109,12 @@ public class MaidBackpackCache {
             int insertIndex = containers.size();
             for (int i = 1; i < containers.size(); i++) {
                 ContainerRef ref = containers.get(i);
-                if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
-                if (newRef.compareTo(backpackRef) >= 0) continue;
+                if (!(ref instanceof BackpackSlotRef backpackRef)) {
+                    continue;
+                }
+                if (newRef.compareTo(backpackRef) >= 0) {
+                    continue;
+                }
                 insertIndex = i;
                 break;
             }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
@@ -1,0 +1,205 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.curios.CuriosCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+
+/**
+ * 女仆容器缓存，缓存女仆的容器列表（物品栏 + Curios 栏上的背包）
+ * 容器优先级：物品栏（永远为首个元素）> back 槽位背包 > trinkets 槽位背包 > 其他槽位
+ * 同槽位类型按 slotIndex 排序
+ */
+public class MaidBackpackCache {
+    private static final WeakHashMap<EntityMaid, List<ContainerRef>> CACHE = new WeakHashMap<>();
+
+    public static abstract class ContainerRef {
+        public abstract boolean containing(ItemStack itemToCheck);
+        public abstract ItemStack insert(ItemStack itemstack, boolean simulate);
+    }
+
+    public static class MaidInventoryRef extends ContainerRef {
+        private final EntityMaid maid;
+
+        public MaidInventoryRef(EntityMaid maid) {
+            this.maid = maid;
+        }
+
+        @Override
+        public boolean containing(ItemStack itemToCheck) {
+            IItemHandler inv = maid.getAvailableInv(false);
+            for (int i = 0; i < inv.getSlots(); i++) {
+                ItemStack stackInSlot = inv.getStackInSlot(i);
+                if (stackInSlot.isEmpty()) continue;
+                if (ItemStack.isSameItemSameTags(stackInSlot, itemToCheck)) return true;
+            }
+            return false;
+        }
+
+        @Override
+        public ItemStack insert(ItemStack itemstack, boolean simulate) {
+            return ItemHandlerHelper.insertItemStacked(maid.getAvailableInv(false), itemstack, simulate);
+        }
+    }
+
+    public static class BackpackSlotRef extends ContainerRef {
+        public final String slotType;
+        public final int slotIndex;
+        public final int priority;
+        private final EntityMaid maid;
+
+        public BackpackSlotRef(EntityMaid maid, String slotType, int slotIndex) {
+            this.maid = maid;
+            this.slotType = slotType;
+            this.slotIndex = slotIndex;
+            this.priority = SBackpackCuriosCompat.getSlotPriority(slotType);
+        }
+
+        public ItemStack getBackpackStack() {
+            return CuriosApi.getCuriosInventory(maid)
+                    .map(handler -> handler.getStacksHandler(slotType)
+                            .map(stacksHandler -> {
+                                IDynamicStackHandler stacks = stacksHandler.getStacks();
+                                if (slotIndex >= stacks.getSlots()) return ItemStack.EMPTY;
+                                
+                                ItemStack stack = stacks.getStackInSlot(slotIndex);
+                                if (SBackpackCompat.isBackpack(stack)) return stack;
+
+                                return ItemStack.EMPTY;
+                            })
+                            .orElse(ItemStack.EMPTY))
+                    .orElse(ItemStack.EMPTY);
+        }
+
+        @Override
+        public boolean containing(ItemStack itemToCheck) {
+            ItemStack backpackStack = getBackpackStack();
+            if (backpackStack.isEmpty()) return false;
+
+            return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
+                    .map(wrapper -> {
+                        ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+                        for (int i = 0; i < inv.getSlots(); i++) {
+                            ItemStack stackInSlot = inv.getStackInSlot(i);
+                            if (stackInSlot.isEmpty()) continue;
+                            if (ItemStack.isSameItemSameTags(stackInSlot, itemToCheck)) return true;
+                        }
+                        return false;
+                    })
+                    .orElse(false);
+        }
+
+        @Override
+        public ItemStack insert(ItemStack itemstack, boolean simulate) {
+            ItemStack backpackStack = getBackpackStack();
+            if (backpackStack.isEmpty()) return itemstack;
+
+            return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
+                    .map(wrapper -> {
+                        ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+                        return ItemHandlerHelper.insertItemStacked(inv, itemstack, simulate);
+                    })
+                    .orElse(itemstack);
+        }
+
+        public int compareTo(BackpackSlotRef other) {
+            int priCmp = Integer.compare(this.priority, other.priority);
+            if (priCmp != 0) return priCmp;
+            return Integer.compare(this.slotIndex, other.slotIndex);
+        }
+    }
+
+    public static List<ContainerRef> getContainers(EntityMaid maid) {
+        List<ContainerRef> containers = CACHE.get(maid);
+        if (containers == null) {
+            containers = buildContainerRefs(maid);
+            CACHE.put(maid, containers);
+        }
+        return containers;
+    }
+
+    public static void onEquipped(EntityMaid maid, String slotType, int slotIndex) {
+        List<ContainerRef> containers = getContainers(maid);
+        BackpackSlotRef    newRef     = new BackpackSlotRef(maid, slotType, slotIndex);
+
+        for (int i = 1; i < containers.size(); i++) {
+            ContainerRef ref = containers.get(i);
+            if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
+            if (!backpackRef.slotType.equals(slotType)) continue;
+            if (backpackRef.slotIndex != slotIndex) continue;
+            // 槽位类型与槽位索引均相同，无需处理
+            return;
+        }
+
+        int insertIndex = containers.size();
+        for (int i = 1; i < containers.size(); i++) {
+            ContainerRef ref = containers.get(i);
+            if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
+            if (newRef.compareTo(backpackRef) >= 0) continue;
+            insertIndex = i;
+            break;
+        }
+        containers.add(insertIndex, newRef);
+    }
+
+    public static void onUnequipped(EntityMaid maid, String slotType, int slotIndex) {
+        List<ContainerRef> containers = getContainers(maid);
+
+        containers.removeIf(ref -> {
+            if (ref instanceof BackpackSlotRef backpackRef)
+                return backpackRef.slotType.equals(slotType) && backpackRef.slotIndex == slotIndex;
+            return false;
+        });
+    }
+
+    public static void invalidate(EntityMaid maid) {
+        CACHE.remove(maid);
+    }
+
+    private static List<ContainerRef> buildContainerRefs(EntityMaid maid) {
+        List<ContainerRef> containers = new ArrayList<>();
+
+        containers.add(new MaidInventoryRef(maid));
+        if (!CuriosCompat.isLoadedOrEnable()) return containers;
+
+        List<BackpackSlotRef> backpackRefs = new ArrayList<>();
+        CuriosApi.getCuriosInventory(maid).ifPresent(handler -> {
+            for (var entry : handler.getCurios().entrySet()) {
+                String slotType = entry.getKey();
+                ICurioStacksHandler stacksHandler = entry.getValue();
+                IDynamicStackHandler stacks = stacksHandler.getStacks();
+
+                for (int i = 0; i < stacks.getSlots(); i++) {
+                    ItemStack stack = stacks.getStackInSlot(i);
+                    if (!SBackpackCompat.isBackpack(stack)) continue;
+                    backpackRefs.add(new BackpackSlotRef(maid, slotType, i));
+                }
+            }
+        });
+
+        for (BackpackSlotRef newRef : backpackRefs) {
+            int insertIndex = containers.size();
+            for (int i = 1; i < containers.size(); i++) {
+                ContainerRef ref = containers.get(i);
+                if (!(ref instanceof BackpackSlotRef backpackRef)) continue;
+                if (newRef.compareTo(backpackRef) >= 0) continue;
+                insertIndex = i;
+                break;
+            }
+            containers.add(insertIndex, newRef);
+        }
+
+        return containers;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/MaidBackpackCache.java
@@ -8,12 +8,14 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
 import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.WeakHashMap;
 
 /**
@@ -38,6 +40,7 @@ public class MaidBackpackCache {
 
         @Override
         public boolean containing(ItemStack itemToCheck) {
+            // EntityMaid 里就没找着 O(1) 的方法，遂遍历
             IItemHandler inv = maid.getAvailableInv(false);
             for (int i = 0; i < inv.getSlots(); i++) {
                 ItemStack stackInSlot = inv.getStackInSlot(i);
@@ -90,12 +93,9 @@ public class MaidBackpackCache {
             return backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance())
                     .map(wrapper -> {
                         ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
-                        for (int i = 0; i < inv.getSlots(); i++) {
-                            ItemStack stackInSlot = inv.getStackInSlot(i);
-                            if (stackInSlot.isEmpty()) continue;
-                            if (ItemStack.isSameItemSameTags(stackInSlot, itemToCheck)) return true;
-                        }
-                        return false;
+                        Set<ItemStackKey> trackedStacks = inv.getTrackedStacks();
+                        return trackedStacks.stream()
+                                .anyMatch(key -> ItemStack.isSameItemSameTags(key.getStack(), itemToCheck));
                     })
                     .orElse(false);
         }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
@@ -1,35 +1,26 @@
 package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
 
+import com.google.common.collect.Maps;
+import net.minecraft.Util;
 import net.minecraftforge.common.MinecraftForge;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class SBackpackCuriosCompat {
-    private static boolean IS_LOADED = false;
-
+    private static final int DEFAULT_PRIORITY = 100;
     /**
      * Curios 槽位中背包优先级，决定背包的拾取顺序
      * 优先交互 back 槽位中的背包
      */
-    private static final Map<String, Integer> SLOT_PRIORITY = new HashMap<>();
-    private static final int DEFAULT_PRIORITY = 100;
-
-    static {
-        SLOT_PRIORITY.put("back", 0);
-        SLOT_PRIORITY.put("trinkets", 1);
-    }
+    private static final Map<String, Integer> SLOT_PRIORITY = Util.make(Maps.newHashMap(), map -> {
+        map.put("back", 0);
+        map.put("trinkets", 1);
+    });
 
     public static void init() {
-        if (IS_LOADED) return;
-        IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new BackpackCuriosEquipEventHandler());
         MinecraftForge.EVENT_BUS.register(new BackpackPickupEventHandler());
         MinecraftForge.EVENT_BUS.register(new BackpackRequestItemEventHandler());
-    }
-
-    public static boolean isLoaded() {
-        return IS_LOADED;
     }
 
     public static int getSlotPriority(String slotType) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
@@ -1,0 +1,37 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios;
+
+import net.minecraftforge.common.MinecraftForge;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SBackpackCuriosCompat {
+    private static boolean IS_LOADED = false;
+
+    /**
+     * Curios 槽位中背包优先级，决定背包的拾取顺序
+     * 优先交互 back 槽位中的背包
+     */
+    private static final Map<String, Integer> SLOT_PRIORITY = new HashMap<>();
+    private static final int DEFAULT_PRIORITY = 100;
+
+    static {
+        SLOT_PRIORITY.put("back", 0);
+        SLOT_PRIORITY.put("trinkets", 1);
+    }
+
+    public static void init() {
+        if (IS_LOADED) return;
+        IS_LOADED = true;
+        MinecraftForge.EVENT_BUS.register(new BackpackCuriosEquipEventHandler());
+        MinecraftForge.EVENT_BUS.register(new BackpackPickupEventHandler());
+    }
+
+    public static boolean isLoaded() {
+        return IS_LOADED;
+    }
+
+    public static int getSlotPriority(String slotType) {
+        return SLOT_PRIORITY.getOrDefault(slotType, DEFAULT_PRIORITY);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/SBackpackCuriosCompat.java
@@ -25,6 +25,7 @@ public class SBackpackCuriosCompat {
         IS_LOADED = true;
         MinecraftForge.EVENT_BUS.register(new BackpackCuriosEquipEventHandler());
         MinecraftForge.EVENT_BUS.register(new BackpackPickupEventHandler());
+        MinecraftForge.EVENT_BUS.register(new BackpackRequestItemEventHandler());
     }
 
     public static boolean isLoaded() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/BackpackSlotRef.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/BackpackSlotRef.java
@@ -1,0 +1,83 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref;
+
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.SBackpackCuriosCompat;
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.p3pp3rf1y.sophisticatedbackpacks.api.CapabilityBackpackWrapper;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ITrackedContentsItemHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+
+import java.util.Set;
+
+public class BackpackSlotRef implements ContainerRef {
+    public final String slotType;
+    public final int slotIndex;
+    public final int priority;
+    private final EntityMaid maid;
+
+    public BackpackSlotRef(EntityMaid maid, String slotType, int slotIndex) {
+        this.maid = maid;
+        this.slotType = slotType;
+        this.slotIndex = slotIndex;
+        this.priority = SBackpackCuriosCompat.getSlotPriority(slotType);
+    }
+
+    public ItemStack getBackpackStack() {
+        var inventory = CuriosApi.getCuriosInventory(maid);
+        return inventory.map(handler -> handler.getStacksHandler(slotType)
+                .map(stacksHandler -> {
+                    IDynamicStackHandler stacks = stacksHandler.getStacks();
+                    if (slotIndex >= stacks.getSlots()) {
+                        return ItemStack.EMPTY;
+                    }
+
+                    ItemStack stack = stacks.getStackInSlot(slotIndex);
+                    if (SBackpackCompat.isBackpack(stack)) {
+                        return stack;
+                    }
+
+                    return ItemStack.EMPTY;
+                }).orElse(ItemStack.EMPTY)
+        ).orElse(ItemStack.EMPTY);
+    }
+
+    @Override
+    public boolean containing(ItemStack itemToCheck) {
+        ItemStack backpackStack = getBackpackStack();
+        if (backpackStack.isEmpty()) {
+            return false;
+        }
+        var capability = backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance());
+        return capability.map(wrapper -> {
+            ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+            Set<ItemStackKey> trackedStacks = inv.getTrackedStacks();
+            return trackedStacks.stream()
+                    .anyMatch(key -> ItemStack.isSameItemSameTags(key.getStack(), itemToCheck));
+        }).orElse(false);
+    }
+
+    @Override
+    public ItemStack insert(ItemStack itemstack, boolean simulate) {
+        ItemStack backpackStack = getBackpackStack();
+        if (backpackStack.isEmpty()) {
+            return itemstack;
+        }
+        var capability = backpackStack.getCapability(CapabilityBackpackWrapper.getCapabilityInstance());
+        return capability.map(wrapper -> {
+            ITrackedContentsItemHandler inv = wrapper.getInventoryForUpgradeProcessing();
+            return ItemHandlerHelper.insertItemStacked(inv, itemstack, simulate);
+        }).orElse(itemstack);
+    }
+
+    public int compareTo(BackpackSlotRef other) {
+        int priorityCompare = Integer.compare(this.priority, other.priority);
+        if (priorityCompare != 0) {
+            return priorityCompare;
+        }
+        return Integer.compare(this.slotIndex, other.slotIndex);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/ContainerRef.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/ContainerRef.java
@@ -1,0 +1,9 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref;
+
+import net.minecraft.world.item.ItemStack;
+
+public interface ContainerRef {
+    boolean containing(ItemStack itemToCheck);
+
+    ItemStack insert(ItemStack itemStack, boolean simulate);
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/MaidInventoryRef.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/sbackpack/curios/ref/MaidInventoryRef.java
@@ -1,0 +1,36 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.curios.ref;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+public class MaidInventoryRef implements ContainerRef {
+    private final EntityMaid maid;
+
+    public MaidInventoryRef(EntityMaid maid) {
+        this.maid = maid;
+    }
+
+    @Override
+    public boolean containing(ItemStack itemToCheck) {
+        // 女仆物品栏不存在 O(1) 复杂度的物品包含方法，只能遍历
+        IItemHandler inv = maid.getAvailableInv(false);
+        for (int i = 0; i < inv.getSlots(); i++) {
+            ItemStack stackInSlot = inv.getStackInSlot(i);
+            if (stackInSlot.isEmpty()) {
+                continue;
+            }
+            if (ItemStack.isSameItemSameTags(stackInSlot, itemToCheck)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ItemStack insert(ItemStack itemstack, boolean simulate) {
+        IItemHandler inv = maid.getAvailableInv(false);
+        return ItemHandlerHelper.insertItemStacked(inv, itemstack, simulate);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidBreathAirTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidBreathAirTask.java
@@ -6,6 +6,7 @@ import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.BaubleItemHandler;
 import com.github.tartaricacid.touhoulittlemaid.network.NetworkHandler;
 import com.github.tartaricacid.touhoulittlemaid.network.message.SpawnParticleMessage;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
@@ -25,7 +26,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.NodeEvaluator;
-import net.minecraftforge.items.wrapper.RangedWrapper;
 
 import java.util.List;
 import java.util.Optional;
@@ -122,7 +122,11 @@ public class MaidBreathAirTask extends Behavior<EntityMaid> {
 
         // 尝试在背包中寻找食物放入
         boolean hasFood = false;
-        RangedWrapper backpackInv = maid.getAvailableBackpackInv();
+        var backpackInv = maid.getAvailableBackpackInv();
+
+        // 若没有食物则借助此调用触发 MaidRequestItemEvent 来尝试获取食物
+        ItemsUtil.findStackSlot(backpackInv, stack -> this.isBreatheFood(maid, stack));
+
         for (int i = 0; i < backpackInv.getSlots(); i++) {
             ItemStack stack = backpackInv.getStackInSlot(i);
             if (stack.isEmpty()) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidFeedOwnerTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidFeedOwnerTask.java
@@ -4,6 +4,7 @@ import com.github.tartaricacid.touhoulittlemaid.advancements.maid.TriggerType;
 import com.github.tartaricacid.touhoulittlemaid.api.task.IFeedTask;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.init.InitTrigger;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -57,6 +58,10 @@ public class MaidFeedOwnerTask extends MaidCheckRateTask {
             IntList highFoods = new IntArrayList();
 
             CombinedInvWrapper inv = maid.getAvailableInv(true);
+
+            // 若没有食物则借助此调用触发 MaidRequestItemEvent 来尝试获取食物
+            ItemsUtil.findStackSlot(inv, stack -> task.isFood(stack, player));
+
             for (int i = 0; i < inv.getSlots(); ++i) {
                 ItemStack stack = inv.getStackInSlot(i);
                 if (task.isFood(stack, player)) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHealSelfTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHealSelfTask.java
@@ -3,12 +3,13 @@ package com.github.tartaricacid.touhoulittlemaid.entity.ai.brain.task;
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.IMaidMeal;
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.MaidMealType;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.DefaultMaidHealSelfMeal;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.wrapper.RangedWrapper;
 
 import java.util.List;
 
@@ -63,7 +64,11 @@ public class MaidHealSelfTask extends MaidCheckRateTask {
 
         // 尝试在背包中寻找食物放入
         boolean hasFood = false;
-        RangedWrapper backpackInv = maid.getAvailableBackpackInv();
+        var backpackInv = maid.getAvailableBackpackInv();
+
+        // 若没有食物则借助此调用触发 MaidRequestItemEvent 来尝试获取食物
+        ItemsUtil.findStackSlot(backpackInv, DefaultMaidHealSelfMeal::isHealMeal);
+
         swapItemCheck:
         for (int i = 0; i < backpackInv.getSlots(); i++) {
             ItemStack stack = backpackInv.getStackInSlot(i);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
@@ -2,18 +2,16 @@ package com.github.tartaricacid.touhoulittlemaid.entity.ai.brain.task;
 
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.IMaidMeal;
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.MaidMealType;
-import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.favorability.FavorabilityManager;
 import com.github.tartaricacid.touhoulittlemaid.entity.favorability.Type;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.DefaultMaidWorkMeal;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
-import com.github.tartaricacid.touhoulittlemaid.event.MaidMealRegConfigEvent;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.wrapper.RangedWrapper;
 
 import java.util.List;
 
@@ -67,10 +65,11 @@ public class MaidWorkMealTask extends MaidCheckRateTask {
 
         // 尝试在背包中寻找食物放入
         boolean hasFood = false;
-        RangedWrapper backpackInv = maid.getAvailableBackpackInv();
-        ItemsUtil.findStackSlot(backpackInv, stack ->
-                stack.isEdible() && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_WORK_MEALS_BLOCK_LIST.get())
-                && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.WORK_MEAL_REGEX));
+        var backpackInv = maid.getAvailableBackpackInv();
+
+        // 若没有食物则借助此调用触发 MaidRequestItemEvent 来尝试获取食物
+        ItemsUtil.findStackSlot(backpackInv, DefaultMaidWorkMeal::isWorkMeal);
+
         swapItemCheck:
         for (int i = 0; i < backpackInv.getSlots(); i++) {
             ItemStack stack = backpackInv.getStackInSlot(i);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
@@ -2,10 +2,13 @@ package com.github.tartaricacid.touhoulittlemaid.entity.ai.brain.task;
 
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.IMaidMeal;
 import com.github.tartaricacid.touhoulittlemaid.api.task.meal.MaidMealType;
+import com.github.tartaricacid.touhoulittlemaid.config.subconfig.MaidConfig;
 import com.github.tartaricacid.touhoulittlemaid.entity.favorability.FavorabilityManager;
 import com.github.tartaricacid.touhoulittlemaid.entity.favorability.Type;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
+import com.github.tartaricacid.touhoulittlemaid.event.MaidMealRegConfigEvent;
+import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
@@ -65,6 +68,9 @@ public class MaidWorkMealTask extends MaidCheckRateTask {
         // 尝试在背包中寻找食物放入
         boolean hasFood = false;
         RangedWrapper backpackInv = maid.getAvailableBackpackInv();
+        ItemsUtil.findStackSlot(backpackInv, stack ->
+                stack.isEdible() && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_WORK_MEALS_BLOCK_LIST.get())
+                && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.WORK_MEAL_REGEX));
         swapItemCheck:
         for (int i = 0; i < backpackInv.getSlots(); i++) {
             ItemStack stack = backpackInv.getStackInSlot(i);

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
@@ -772,13 +772,7 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
             if (!simulate) {
                 // 这是向客户端同步数据用的，如果加了这个方法，会有短暂的拾取动画和音效
                 this.take(entityItem, count - itemstack.getCount());
-                if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(this))) {
-                    pickupSoundCount--;
-                    if (pickupSoundCount == 0) {
-                        this.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
-                        pickupSoundCount = 5;
-                    }
-                }
+                this.tryPlayMaidPickupSound();
                 ItemStack copy = new ItemStack(itemstack.getItem(), count - itemstack.getCount());
                 // 如果遍历塞完后发现为空了
                 if (itemstack.isEmpty()) {
@@ -803,13 +797,7 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
         if (!this.level.isClientSide && entityXPOrb.isAlive() && entityXPOrb.tickCount > 2) {
             // 这是向客户端同步数据用的，如果加了这个方法，会有短暂的拾取动画和音效
             this.take(entityXPOrb, 1);
-            if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(this))) {
-                pickupSoundCount--;
-                if (pickupSoundCount == 0) {
-                    this.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
-                    pickupSoundCount = 5;
-                }
-            }
+            this.tryPlayMaidPickupSound();
 
             // 对经验修补的应用，因为全部来自于原版，所以效果也是相同的
             IItemHandler allItems = new CombinedInvWrapper(armorInvWrapper, handsInvWrapper, maidBauble);
@@ -834,13 +822,7 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
         if (!this.level.isClientSide && powerPoint.isAlive() && powerPoint.throwTime == 0) {
             // 这是向客户端同步数据用的，如果加了这个方法，会有短暂的拾取动画和音效
             powerPoint.take(this, 1);
-            if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(this))) {
-                pickupSoundCount--;
-                if (pickupSoundCount == 0) {
-                    this.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
-                    pickupSoundCount = 5;
-                }
-            }
+            this.tryPlayMaidPickupSound();
 
             // 对经验修补的应用，因为全部来自于原版，所以效果也是相同的
             LazyOptional<IItemHandler> allItems = this.getCapability(ForgeCapabilities.ITEM_HANDLER, null);
@@ -896,18 +878,22 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
             if (!simulate) {
                 // 这是向客户端同步数据用的，如果加了这个方法，会有短暂的拾取动画和音效
                 this.take(arrow, 1);
-                if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(this))) {
-                    pickupSoundCount--;
-                    if (pickupSoundCount == 0) {
-                        this.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
-                        pickupSoundCount = 5;
-                    }
-                }
+                this.tryPlayMaidPickupSound();
                 arrow.discard();
             }
             return true;
         }
         return false;
+    }
+
+    public void tryPlayMaidPickupSound() {
+        if (!MinecraftForge.EVENT_BUS.post(new MaidPlaySoundEvent(this))) {
+            pickupSoundCount--;
+            if (pickupSoundCount == 0) {
+                this.playSound(InitSounds.MAID_ITEM_GET.get(), 1, 1);
+                pickupSoundCount = 5;
+            }
+        }
     }
 
     private ItemStack getArrowFromEntity(AbstractArrow entity) {
@@ -2319,13 +2305,23 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
         return maidInv;
     }
 
+    /**
+     * 返回 MaidInvWrapper，方便触发 MaidRequestItemEvent 事件时使用
+     */
     public MaidInvWrapper getAvailableInv(boolean handsFirst) {
-        RangedWrapper combinedInvWrapper = this.getAvailableBackpackInv();
-        return handsFirst ? new MaidInvWrapper(this, handsInvWrapper, combinedInvWrapper) : new MaidInvWrapper(this, combinedInvWrapper, handsInvWrapper);
+        int maxContainerIndex = getMaidBackpackType().getAvailableMaxContainerIndex();
+        RangedWrapper combinedInvWrapper = new RangedWrapper(maidInv, 0, maxContainerIndex);
+        return handsFirst ? new MaidInvWrapper(this, handsInvWrapper, combinedInvWrapper)
+                : new MaidInvWrapper(this, combinedInvWrapper, handsInvWrapper);
     }
 
-    public RangedWrapper getAvailableBackpackInv() {
-        return new RangedWrapper(maidInv, 0, getMaidBackpackType().getAvailableMaxContainerIndex());
+    /**
+     * 返回 MaidInvWrapper，方便触发 MaidRequestItemEvent 事件时使用
+     */
+    public MaidInvWrapper getAvailableBackpackInv() {
+        int maxContainerIndex = getMaidBackpackType().getAvailableMaxContainerIndex();
+        RangedWrapper rangedWrapper = new RangedWrapper(maidInv, 0, maxContainerIndex);
+        return new MaidInvWrapper(this, rangedWrapper);
     }
 
     public EntityHandsInvWrapper getHandsInvWrapper() {
@@ -2838,5 +2834,23 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
                 this.level.addParticle(option, pos.x, pos.y, pos.z, speed.x, speed.y + 0.05, speed.z);
             }
         }
+    }
+
+    /**
+     * 因为部分 idea 插件会检查 Map 类里，这些对象做 key 时，是否重写了 equals 和 hashCode 方法，
+     * 故这里必须重写这两个方法，但实际上并不需要修改默认父类的实现
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * 因为部分 idea 插件会检查 Map 类里，这些对象做 key 时，是否重写了 equals 和 hashCode 方法，
+     * 故这里必须重写这两个方法，但实际上并不需要修改默认父类的实现
+     */
+    @Override
+    public boolean equals(Object pObject) {
+        return super.equals(pObject);
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/passive/EntityMaid.java
@@ -53,6 +53,7 @@ import com.github.tartaricacid.touhoulittlemaid.inventory.container.config.MaidC
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.BaubleItemHandler;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidBackpackHandler;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidHandsInvWrapper;
+import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidInvWrapper;
 import com.github.tartaricacid.touhoulittlemaid.item.ItemFilm;
 import com.github.tartaricacid.touhoulittlemaid.mixin.accessor.ArrowAccessor;
 import com.github.tartaricacid.touhoulittlemaid.network.NetworkHandler;
@@ -2318,9 +2319,9 @@ public class EntityMaid extends TamableAnimal implements CrossbowAttackMob, IMai
         return maidInv;
     }
 
-    public CombinedInvWrapper getAvailableInv(boolean handsFirst) {
+    public MaidInvWrapper getAvailableInv(boolean handsFirst) {
         RangedWrapper combinedInvWrapper = this.getAvailableBackpackInv();
-        return handsFirst ? new CombinedInvWrapper(handsInvWrapper, combinedInvWrapper) : new CombinedInvWrapper(combinedInvWrapper, handsInvWrapper);
+        return handsFirst ? new MaidInvWrapper(this, handsInvWrapper, combinedInvWrapper) : new MaidInvWrapper(this, combinedInvWrapper, handsInvWrapper);
     }
 
     public RangedWrapper getAvailableBackpackInv() {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidHealSelfMeal.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidHealSelfMeal.java
@@ -14,10 +14,15 @@ import net.minecraft.world.item.ItemStack;
 public class DefaultMaidHealSelfMeal implements IMaidMeal {
     private static final int MAX_PROBABILITY = 5;
 
+    public static boolean isHealMeal(ItemStack stack) {
+        return stack.isEdible()
+               && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_HEAL_MEALS_BLOCK_LIST.get())
+               && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.HEAL_MEAL_REGEX);
+    }
+
     @Override
     public boolean canMaidEat(EntityMaid maid, ItemStack stack, InteractionHand hand) {
-        return stack.isEdible() && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_HEAL_MEALS_BLOCK_LIST.get())
-               && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.HEAL_MEAL_REGEX);
+        return isHealMeal(stack);
     }
 
     @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidHomeMeal.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidHomeMeal.java
@@ -15,10 +15,15 @@ import net.minecraft.world.item.ItemStack;
 public class DefaultMaidHomeMeal implements IMaidMeal {
     private static final int MAX_PROBABILITY = 15;
 
+    public static boolean isHomeMeal(ItemStack stack) {
+        return stack.isEdible()
+               && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_HOME_MEALS_BLOCK_LIST.get())
+               && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.HOME_MEAL_REGEX);
+    }
+
     @Override
     public boolean canMaidEat(EntityMaid maid, ItemStack stack, InteractionHand hand) {
-        return stack.isEdible() && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_HOME_MEALS_BLOCK_LIST.get())
-                && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.HOME_MEAL_REGEX);
+        return isHomeMeal(stack);
     }
 
     @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidWorkMeal.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/task/meal/DefaultMaidWorkMeal.java
@@ -15,10 +15,15 @@ import net.minecraft.world.item.ItemStack;
 public class DefaultMaidWorkMeal implements IMaidMeal {
     private static final int MAX_PROBABILITY = 100;
 
+    public static boolean isWorkMeal(ItemStack stack) {
+        return stack.isEdible()
+               && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_WORK_MEALS_BLOCK_LIST.get())
+               && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.WORK_MEAL_REGEX);
+    }
+
     @Override
     public boolean canMaidEat(EntityMaid maid, ItemStack stack, InteractionHand hand) {
-        return stack.isEdible() && !IMaidMeal.isBlockList(stack, MaidConfig.MAID_WORK_MEALS_BLOCK_LIST.get())
-               && !IMaidMeal.isBlockList(stack, MaidMealRegConfigEvent.WORK_MEAL_REGEX);
+        return isWorkMeal(stack);
     }
 
     @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/handler/MaidInvWrapper.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/handler/MaidInvWrapper.java
@@ -1,0 +1,23 @@
+package com.github.tartaricacid.touhoulittlemaid.inventory.handler;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.wrapper.CombinedInvWrapper;
+
+/**
+ * 女仆物品栏包装，继承自 {@link CombinedInvWrapper} 并保持对女仆实体的引用。
+ * 以此在只有 {@link IItemHandler} 引用的情况下，
+ * 获取关联的女仆实体，从而支持对其持有的其它物品的访问。
+ */
+public class MaidInvWrapper extends CombinedInvWrapper {
+    private final EntityMaid maid;
+
+    public MaidInvWrapper(EntityMaid maid, IItemHandlerModifiable... itemHandler) {
+        super(itemHandler);
+        this.maid = maid;
+    }
+
+    public EntityMaid getMaid() {
+        return maid;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
@@ -67,10 +67,11 @@ public final class ItemsUtil {
     /**
      * 如果传入的 handler 是 {@link MaidInvWrapper}，
      * 在物品栏中找不到时会触发 {@link MaidRequestItemEvent} 事件尝试从外部存储请求物品到物品栏，再次查找。
-     * 
+     *
      * @return 如果没找到，返回 -1
      */
     public static int findStackSlot(IItemHandler handler, Predicate<ItemStack> filter, int maxCount) {
+        // 先正常在普通物品栏中查找
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack stack = handler.getStackInSlot(i);
             if (filter.test(stack)) {
@@ -78,23 +79,28 @@ public final class ItemsUtil {
             }
         }
 
-        if (!(handler instanceof MaidInvWrapper maidInv)) return -1;
+        // 如果没找到，并且 handler 是 MaidInvWrapper，就触发事件请求物品后再找一次
+        if (!(handler instanceof MaidInvWrapper maidInv) || maidInv.getMaid().level.isClientSide) {
+            return -1;
+        }
 
-        EntityMaid maid = maidInv.getMaid();
-        if (maid.level().isClientSide) return -1;
-
-        MaidRequestItemEvent event = new MaidRequestItemEvent(maid, filter, maxCount);
+        // 触发事件请求物品，让外部存储（如精妙背包等）把物品放到物品栏里
+        MaidRequestItemEvent event = new MaidRequestItemEvent(maidInv.getMaid(), filter, maxCount);
         MinecraftForge.EVENT_BUS.post(event);
         ItemStack requested = event.getRequestedItem();
-        if (requested.isEmpty()) return -1;
+        // 如果请求的物品为空，说明没有外部存储提供物品，直接返回 -1
+        if (requested.isEmpty()) {
+            return -1;
+        }
 
+        // 再次查找物品栏，找到该物品
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack stack = handler.getStackInSlot(i);
             if (filter.test(stack)) {
                 return i;
             }
         }
-        
+
         return -1;
     }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/ItemsUtil.java
@@ -1,8 +1,10 @@
 package com.github.tartaricacid.touhoulittlemaid.util;
 
 import com.github.tartaricacid.touhoulittlemaid.api.bauble.IMaidBauble;
+import com.github.tartaricacid.touhoulittlemaid.api.event.MaidRequestItemEvent;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.BaubleItemHandler;
+import com.github.tartaricacid.touhoulittlemaid.inventory.handler.MaidInvWrapper;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -12,6 +14,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.items.wrapper.PlayerMainInvWrapper;
@@ -58,12 +61,40 @@ public final class ItemsUtil {
      * @return 如果没找到，返回 -1
      */
     public static int findStackSlot(IItemHandler handler, Predicate<ItemStack> filter) {
+        return findStackSlot(handler, filter, -1);
+    }
+
+    /**
+     * 如果传入的 handler 是 {@link MaidInvWrapper}，
+     * 在物品栏中找不到时会触发 {@link MaidRequestItemEvent} 事件尝试从外部存储请求物品到物品栏，再次查找。
+     * 
+     * @return 如果没找到，返回 -1
+     */
+    public static int findStackSlot(IItemHandler handler, Predicate<ItemStack> filter, int maxCount) {
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack stack = handler.getStackInSlot(i);
             if (filter.test(stack)) {
                 return i;
             }
         }
+
+        if (!(handler instanceof MaidInvWrapper maidInv)) return -1;
+
+        EntityMaid maid = maidInv.getMaid();
+        if (maid.level().isClientSide) return -1;
+
+        MaidRequestItemEvent event = new MaidRequestItemEvent(maid, filter, maxCount);
+        MinecraftForge.EVENT_BUS.post(event);
+        ItemStack requested = event.getRequestedItem();
+        if (requested.isEmpty()) return -1;
+
+        for (int i = 0; i < handler.getSlots(); i++) {
+            ItemStack stack = handler.getStackInSlot(i);
+            if (filter.test(stack)) {
+                return i;
+            }
+        }
+        
         return -1;
     }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/TaskEquipUtil.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/TaskEquipUtil.java
@@ -3,7 +3,6 @@ package com.github.tartaricacid.touhoulittlemaid.util;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.wrapper.RangedWrapper;
 
 import java.util.function.Predicate;
 
@@ -19,7 +18,7 @@ public final class TaskEquipUtil {
         if (predicate.test(maid.getMainHandItem())) {
             return true;
         }
-        RangedWrapper backpack = maid.getAvailableBackpackInv();
+        var backpack = maid.getAvailableBackpackInv();
         int slot = ItemsUtil.findStackSlot(backpack, predicate);
         if (slot >= 0) {
             int count = backpack.getStackInSlot(slot).getCount();
@@ -43,7 +42,7 @@ public final class TaskEquipUtil {
         if (maid.getMainHandItem().isEmpty()) {
             return false;
         }
-        RangedWrapper backpack = maid.getAvailableBackpackInv();
+        var backpack = maid.getAvailableBackpackInv();
         ItemStack mainHandItem = maid.getMainHandItem();
         for (int i = 0; i < backpack.getSlots(); i++) {
             ItemStack stackInSlot = backpack.getStackInSlot(i);


### PR DESCRIPTION
- 添加了对墓碑生成事件的处理，现在会在女仆死亡时将 Curios 饰品栏中的物品转移到墓碑；
- 添加了女仆与其装备的精妙背包的交互功能，允许女仆在物品栏已满的情况下将拾取到物品放入自己的背包，允许女仆在任务需要消耗物品时尝试从背包获取需要的物品；