### PR TITLE
沉浸式奏乐兼容性修复

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/HardcodedAnimationManger.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/HardcodedAnimationManger.java
@@ -7,7 +7,7 @@ import com.github.tartaricacid.touhoulittlemaid.api.entity.IMaid;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.script.ModelRendererWrapper;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.special.SwimAnimation;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.special.TridentAnimation;
-import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.ImmersiveMelodiesCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client.ImmersiveMelodiesCompat;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.geo.animated.AnimatedGeoModel;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/molang/CtrlBinding.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/animation/gecko/molang/CtrlBinding.java
@@ -1,6 +1,6 @@
 package com.github.tartaricacid.touhoulittlemaid.client.animation.gecko.molang;
 
-import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.ImmersiveMelodiesCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client.ImmersiveMelodiesCompat;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.molang.binding.ContextBinding;
 
 public class CtrlBinding extends ContextBinding {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/entity/GeckoMaidEntity.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/entity/GeckoMaidEntity.java
@@ -6,7 +6,7 @@ import com.github.tartaricacid.touhoulittlemaid.api.entity.IMaid;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.HardcodedAnimationManger;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.gecko.AnimationManager;
 import com.github.tartaricacid.touhoulittlemaid.client.resource.pojo.MaidModelInfo;
-import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.ImmersiveMelodiesCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client.ImmersiveMelodiesCompat;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.AnimatableEntity;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.controller.AnimationController;
 import com.github.tartaricacid.touhoulittlemaid.geckolib3.core.event.predicate.AnimationEvent;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/init/ClientSetupEvent.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/init/ClientSetupEvent.java
@@ -11,7 +11,7 @@ import com.github.tartaricacid.touhoulittlemaid.client.overlay.BroomTipsOverlay;
 import com.github.tartaricacid.touhoulittlemaid.client.overlay.MaidTipsOverlay;
 import com.github.tartaricacid.touhoulittlemaid.client.resource.LegacyPackRepositorySource;
 import com.github.tartaricacid.touhoulittlemaid.client.resource.listener.EmojiReloadListener;
-import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.ImmersiveMelodiesCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client.ImmersiveMelodiesCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.oculus.OculusCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.patpat.PatPatCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.ponder.PonderCompat;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/CompatAnimation.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/CompatAnimation.java
@@ -1,4 +1,4 @@
-package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies;
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client;
 
 import com.github.tartaricacid.simplebedrockmodel.client.bedrock.model.BedrockPart;
 import com.github.tartaricacid.touhoulittlemaid.api.animation.ICustomAnimation;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/ImmersiveMelodiesCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/ImmersiveMelodiesCompat.java
@@ -1,4 +1,4 @@
-package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies;
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client;
 
 import com.github.tartaricacid.touhoulittlemaid.client.animation.HardcodedAnimationManger;
 import com.github.tartaricacid.touhoulittlemaid.client.animation.gecko.molang.CtrlBinding;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/ImmersiveMelodiesCompatInner.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/ImmersiveMelodiesCompatInner.java
@@ -1,4 +1,4 @@
-package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies;
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client;
 
 import com.github.tartaricacid.touhoulittlemaid.client.animation.gecko.molang.CtrlBinding;
 import com.github.tartaricacid.touhoulittlemaid.client.entity.GeckoMaidEntity;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/MaidArmsAndHeadAccessor.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/client/MaidArmsAndHeadAccessor.java
@@ -1,4 +1,4 @@
-package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies;
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.client;
 
 import com.github.tartaricacid.simplebedrockmodel.client.bedrock.model.BedrockPart;
 import immersive_melodies.client.animation.accessors.ModelAccessor;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/server/ImmersiveMelodiesCompatServerInner.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/server/ImmersiveMelodiesCompatServerInner.java
@@ -1,0 +1,10 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.server;
+
+import immersive_melodies.item.InstrumentItem;
+import net.minecraft.world.item.ItemStack;
+
+public class ImmersiveMelodiesCompatServerInner {
+    static boolean isInstrumentItem(ItemStack stack) {
+        return stack.getItem() instanceof InstrumentItem;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/server/ImmersiveMelodiesServerCompat.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/compat/immersivemelodies/server/ImmersiveMelodiesServerCompat.java
@@ -1,0 +1,18 @@
+package com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.server;
+
+import net.minecraft.world.item.ItemStack;
+
+public class ImmersiveMelodiesServerCompat {
+    private static boolean IS_LOADED = false;
+
+    public static void init() {
+        IS_LOADED = true;
+    }
+
+    public static boolean isInstrumentItem(ItemStack stack) {
+        if (IS_LOADED) {
+            return ImmersiveMelodiesCompatServerInner.isInstrumentItem(stack);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/init/registry/CompatRegistry.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/init/registry/CompatRegistry.java
@@ -4,6 +4,7 @@ import com.github.tartaricacid.touhoulittlemaid.client.gui.mod.ClothConfigScreen
 import com.github.tartaricacid.touhoulittlemaid.compat.carryon.BlackList;
 import com.github.tartaricacid.touhoulittlemaid.compat.cloth.MenuIntegration;
 import com.github.tartaricacid.touhoulittlemaid.compat.curios.CuriosCompat;
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.server.ImmersiveMelodiesServerCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.patchouli.PatchouliCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.sbackpack.SBackpackCompat;
 import com.github.tartaricacid.touhoulittlemaid.compat.top.TheOneProbeInfo;
@@ -24,6 +25,7 @@ public final class CompatRegistry {
     public static final String CARRY_ON = "carryon";
     public static final String SBACKPACK = "sophisticatedbackpacks";
     public static final String CURIOS = "curios";
+    public static final String IMMERSIVE_MELODIES = "immersive_melodies";
 
     @SubscribeEvent
     public static void onEnqueue(final InterModEnqueueEvent event) {
@@ -42,6 +44,7 @@ public final class CompatRegistry {
         event.enqueueWork(() -> checkModLoad(CARRY_ON, BlackList::addBlackList));
         event.enqueueWork(() -> checkModLoad(SBACKPACK, SBackpackCompat::init));
         event.enqueueWork(() -> checkModLoad(CURIOS, CuriosCompat::init));
+        event.enqueueWork(() -> checkModLoad(IMMERSIVE_MELODIES, ImmersiveMelodiesServerCompat::init));
     }
 
     private static void checkModLoad(String modId, Runnable runnable) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/MobInteractMixin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/MobInteractMixin.java
@@ -1,34 +1,58 @@
 package com.github.tartaricacid.touhoulittlemaid.mixin;
 
+import com.github.tartaricacid.touhoulittlemaid.compat.immersivemelodies.server.ImmersiveMelodiesServerCompat;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * 修复与 Immersive Melodies 模组的兼容性问题
- *
+ * <p>
  * IM 的 MobEntityMixin 在 Mob.interact 的 HEAD 位置注入
  * 当 Mob 手上有乐器时会将其掉落并取消后续交互逻辑
- *
+ * <p>
  * 此处额外注入一个优先级更高的 Mixin，在其之前执行女仆的交互逻辑，
  * 当交互对象是女仆、交互者是主人时，先执行女仆的 mobInteract 逻辑打开 GUI
+ * <p>
  * IM MobEntityMixin 使用默认优先级 1000，此处使用 999 以在其之前执行
  */
 @Mixin(value = Mob.class, priority = 999)
 public class MobInteractMixin {
+    @Shadow
+    @Final
+    private NonNullList<ItemStack> handItems;
+
+    @SuppressWarnings("all")
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void touhouLittleMaid$RightClick(Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
-        if (!((Object) this instanceof EntityMaid maid)) return;
-        if (hand != InteractionHand.MAIN_HAND) return;
-        if (!maid.isOwnedBy(player)) return;
-        
-        InteractionResult result = maid.mobInteract(player, hand);
-        if (result.consumesAction()) cir.setReturnValue(result);
+        if (!((Object) this instanceof EntityMaid maid)) {
+            return;
+        }
+        if (hand != InteractionHand.MAIN_HAND) {
+            return;
+        }
+        if (!maid.isOwnedBy(player)) {
+            return;
+        }
+        // 仅在手上有乐器时，才执行 mixin 过的逻辑，尽可能减少对原版交互逻辑的影响
+        for (ItemStack handItem : this.handItems) {
+            if (ImmersiveMelodiesServerCompat.isInstrumentItem(handItem)) {
+                InteractionResult result = maid.mobInteract(player, hand);
+                if (result.consumesAction()) {
+                    cir.setReturnValue(result);
+                }
+                return;
+            }
+        }
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/MobInteractMixin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/MobInteractMixin.java
@@ -1,0 +1,34 @@
+package com.github.tartaricacid.touhoulittlemaid.mixin;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * 修复与 Immersive Melodies 模组的兼容性问题
+ *
+ * IM 的 MobEntityMixin 在 Mob.interact 的 HEAD 位置注入
+ * 当 Mob 手上有乐器时会将其掉落并取消后续交互逻辑
+ *
+ * 此处额外注入一个优先级更高的 Mixin，在其之前执行女仆的交互逻辑，
+ * 当交互对象是女仆、交互者是主人时，先执行女仆的 mobInteract 逻辑打开 GUI
+ * IM MobEntityMixin 使用默认优先级 1000，此处使用 999 以在其之前执行
+ */
+@Mixin(value = Mob.class, priority = 999)
+public class MobInteractMixin {
+    @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
+    private void touhouLittleMaid$RightClick(Player player, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
+        if (!((Object) this instanceof EntityMaid maid)) return;
+        if (hand != InteractionHand.MAIN_HAND) return;
+        if (!maid.isOwnedBy(player)) return;
+        
+        InteractionResult result = maid.mobInteract(player, hand);
+        if (result.consumesAction()) cir.setReturnValue(result);
+    }
+}

--- a/src/main/resources/touhou_little_maid.mixins.json
+++ b/src/main/resources/touhou_little_maid.mixins.json
@@ -11,6 +11,7 @@
     "ConduitBlockEntityMixin",
     "EntityMixin",
     "FishingHookPredicateMixin",
+    "MobInteractMixin",
     "NavigationMixin",
     "NodeEvaluatorBurningCacher",
     "PersistentEntitySectionManagerMixin",


### PR DESCRIPTION
当女仆演奏乐器时，通过一个更高优先级的 Mixin 来保证右键交互优先执行女仆的 mobInteract 逻辑打开 GUI，避免被 IM 的乐器掉落逻辑干扰