### PR TITLE
fix: 修复与 Alex's Caves 同时安装时骑乘扫帚无法交互的问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityBroom.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/EntityBroom.java
@@ -246,6 +246,16 @@ public class EntityBroom extends AbstractEntityFromItem implements OwnableEntity
         return this.isAlive();
     }
 
+    /**
+     * 当玩家骑在扫帚上时，让扫帚本体不可被选中
+     * 防止其碰撞箱影响正常交互
+     */
+    @Override
+    public boolean isPickable() {
+        boolean hasPlayer = this.getPassengers().stream().anyMatch(e -> e instanceof Player);
+        return hasPlayer ? false : super.isPickable();
+    }
+
     @Override
     protected boolean canAddPassenger(Entity entity) {
         return this.getPassengers().size() < 2;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/EntityMixin.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/mixin/EntityMixin.java
@@ -3,6 +3,7 @@ package com.github.tartaricacid.touhoulittlemaid.mixin;
 import com.github.tartaricacid.touhoulittlemaid.entity.item.EntityBroom;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -33,21 +34,25 @@ public class EntityMixin {
         }
     }
 
+    /**
+     * 修改为在 Entity.move() 中 collide() 调用的前后设置 inPhysicalCheck 标志
+     * 以避免其它 mod 对 collide() 的修改导致 inPhysicalCheck 永久卡在 true 的问题
+     */
     @Inject(
-            method = "collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;",
-            at = @At("HEAD")
+            method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;")
     )
-    private void onCollide(Vec3 pVec, CallbackInfoReturnable<Vec3> cir) {
+    private void beforeCollide(MoverType type, Vec3 movement, CallbackInfo ci) {
         if ((Object) this instanceof EntityBroom broom) {
             broom.inPhysicalCheck = true;
         }
     }
 
     @Inject(
-            method = "collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;",
-            at = @At("RETURN")
+            method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;collide(Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/phys/Vec3;", shift = At.Shift.AFTER)
     )
-    private void onCollideReturn(Vec3 pVec, CallbackInfoReturnable<Vec3> cir) {
+    private void afterCollide(MoverType type, Vec3 movement, CallbackInfo ci) {
         if ((Object) this instanceof EntityBroom broom) {
             broom.inPhysicalCheck = false;
         }


### PR DESCRIPTION
Fixes #1036 

经查发现 Alex's Caves 通过 cancellable HEAD 注入完全替换了 Entity.collide() 方法体， 这导致 mixin/EntityMixin 中原本用于取消物理碰撞的 inPhysicalCheck 的 onCollideReturn 注入永远不会执行， 从而使 inPhysicalCheck 永久卡在 true，扫帚的碰撞箱会一直返回偏大的物理碰撞箱， 该碰撞箱会完全包裹玩家，使玩家无法与外部交互。

此次提交包括两个解决方法：
1. mixin/EntityMixin 中修改了标志修改注入点到 Entity.move() 中调用 collide() 的前后；
2. entity/item/EntityBroom 中重写 isPickable 方法，在玩家骑在扫帚上时让扫帚本体不可被选中；

任意一项修改都可以解决问题。