### PR TITLE
fix：修复浮点误差导致的魔理沙的扫帚的水平移动问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/control/PlayerBroomControl.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/item/control/PlayerBroomControl.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class PlayerBroomControl implements IBroomControl {
     private final EntityBroom broom;
+    private float FCMP_THRE = 1e-4f;
 
     public PlayerBroomControl(EntityBroom broom) {
         this.broom = broom;
@@ -27,10 +28,10 @@ public class PlayerBroomControl implements IBroomControl {
 
     @Override
     public void travel(Player player, EntityMaid maid) {
-        boolean keyForward = player.zza > 0;
-        boolean keyBack = player.zza < 0;
-        boolean keyLeft = player.xxa > 0;
-        boolean keyRight = player.xxa < 0;
+        boolean keyForward = player.zza > FCMP_THRE;
+        boolean keyBack = player.zza < -FCMP_THRE;
+        boolean keyLeft = player.xxa > FCMP_THRE;
+        boolean keyRight = player.xxa < -FCMP_THRE;
         boolean keySneak = player.isShiftKeyDown();
         boolean keyJump = IBroomControl.keyJump(player);
 
@@ -38,7 +39,7 @@ public class PlayerBroomControl implements IBroomControl {
         boolean hasInput = keyForward || keyBack || keyLeft || keyRight || keyJump || keySneak;
 
         if (hasInput) {
-            float strafe = keyLeft ? 0.2f : (keyRight ? -0.2f : 0);
+            float strafe = player.xxa * 0.2f;
             float vertical = 0;
 
             // 垂直移动控制
@@ -51,7 +52,7 @@ public class PlayerBroomControl implements IBroomControl {
                 vertical = -(player.getXRot() - 10) / 360f;
             }
 
-            float forward = keyForward ? 0.375f : (keyBack ? -0.2f : 0);
+            float forward = keyForward ? player.zza * 0.375f : player.zza * 0.2f;
 
             // 玩家基础速度是 0.1，速度二效果是 0.14，为了增加速度效果带来的增益，故这样计算
             double playerSpeed = player.getAttributeValue(Attributes.MOVEMENT_SPEED);


### PR DESCRIPTION
Fixes #1015 骑乘扫帚时，和 leawind's third person 有冲突

经查发现这是一个浮点运算精度问题，导致玩家的水平移动分量被错误判定为非 0。

LTP 在第三人称下会对角度做规范化处理，将负角度转变为正角度，
实际测试中，保持一个方向不变，在第一人称与未加载 LTP 的第三人称视角中，yRot = -210.4588，strafe = 0； 在加载 LTP 的第三人称视角中，yRot = 149.5412，strafe = 0.2；
因此错误引发水平移动。

在对 keyForward 等值加判定阈值后，情况有所改善，但转弯时仍有可能触发该问题。遂将硬编码的 strafe 与 forward 候选值修改为系数乘对应分量。