### PR TITLE
Fixes #1002 使用女仆工作台背包升级精妙背包丢失数据

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/container/backpack/CraftingTableBackpackContainer.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/inventory/container/backpack/CraftingTableBackpackContainer.java
@@ -115,11 +115,12 @@ public class CraftingTableBackpackContainer extends MaidMainContainer {
         if (!level.isClientSide && level.getServer() != null) {
             ServerPlayer serverPlayer = (ServerPlayer) player;
             ItemStack stack1 = ItemStack.EMPTY;
-            Optional<RecipeHolder<CraftingRecipe>> optional = level.getServer().getRecipeManager().getRecipeFor(RecipeType.CRAFTING, container.asCraftInput(), level);
+            CraftingInput craftInput = container.asCraftInput();
+            Optional<RecipeHolder<CraftingRecipe>> optional = level.getServer().getRecipeManager().getRecipeFor(RecipeType.CRAFTING, craftInput, level);
             if (optional.isPresent()) {
                 RecipeHolder<CraftingRecipe> recipe = optional.get();
                 if (result.setRecipeUsed(level, serverPlayer, recipe)) {
-                    ItemStack stack2 = recipe.value().assemble(CraftingInput.of(3, 3, this.getItems()), level.registryAccess());
+                    ItemStack stack2 = recipe.value().assemble(craftInput, level.registryAccess());
                     if (stack2.isItemEnabled(level.enabledFeatures())) {
                         stack1 = stack2;
                     }


### PR DESCRIPTION
Fixes #1002

原版 Recipe API 在 1.20 -> 1.21 时引入 RecipeInput 接口
在之前对代码中，错误的使用了 this.getItems() 来尝试获取 CraftingInput 的内容 这实际返回了玩家的背包内容，而非工作台容器的内容

精妙背包合成升级时应该是会读原背包的 nbt，但由于返回的容器错误，也就无法正确获取原
背包的 nbt，因此造成物品丢失

改为传入正确的 CraftingInput 后，问题得到解决

对该问题的描述，有下列数图为证：
<img width="1854" height="1011" alt="2026-02-11_00 18 33" src="https://github.com/user-attachments/assets/305c7d6a-6abe-4999-aeb8-cdb2201e8d97" />
<img width="1854" height="1011" alt="2026-02-11_00 18 31" src="https://github.com/user-attachments/assets/665c4d38-a16f-4b23-98a5-2adf56139233" />
<img width="1854" height="1011" alt="2026-02-11_00 18 05" src="https://github.com/user-attachments/assets/f7356452-6a9c-40b9-95c0-216868d4a918" />
<img width="1854" height="1011" alt="2026-02-11_00 18 03" src="https://github.com/user-attachments/assets/5959a25f-bc57-471a-94ae-4010a38e9dfd" />
<img width="1854" height="1011" alt="2026-02-11_00 17 59" src="https://github.com/user-attachments/assets/4b4c1f03-d2c1-4776-abda-0a40519b1f35" />

