### PR TITLE
fix: fix boundary for siliconflow stt

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/stt/STTClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/stt/STTClient.java
@@ -54,7 +54,7 @@ public interface STTClient extends Client {
                 T message = GSON.fromJson(string, type);
                 onSuccess.accept(message);
             } else {
-                String message = "HTTP Error Code: %d, Response %s".formatted(statusCode, response);
+                String message = "HTTP Error Code: %d, Response: %s, Response Body: %s".formatted(statusCode, response, string);
                 callback.onFailure(request, new Throwable(message), ErrorCode.REQUEST_RECEIVED_ERROR);
             }
         } catch (JsonSyntaxException e) {

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/http/MultipartBodyBuilder.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/http/MultipartBodyBuilder.java
@@ -46,7 +46,7 @@ public class MultipartBodyBuilder {
     }
 
     public MultipartBody build() throws IOException {
-        String boundary = new BigInteger(256, new SecureRandom()).toString();
+        String boundary = new BigInteger(256, new SecureRandom()).toString(16);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (MultiPartRecord record : parts) {
             out.write(this.getHead(record, boundary));


### PR DESCRIPTION
* Fix SiliconFlow SST HTTP 422 Error

## Changes
* Append the actual response body after the raw response object
* Generate hex boundary string to ensure the boundary length stays under 70 characters ([RFC 2046](http://www.ietf.org/rfc/rfc2046.txt))

## Original Error Log
```
[01:29:10] [ForkJoinPool.commonPool-worker-6/INFO]: [CHAT] 接收语音识别请求时出错：HTTP Error Code: 422, Response (POST https://api.siliconflow.cn/v1/audio/transcriptions) 422
[01:29:10] [ForkJoinPool.commonPool-worker-6/ERROR]: STT request failed: https://api.siliconflow.cn/v1/audio/transcriptions POST, error is HTTP Error Code: 422, Response (POST https://api.siliconflow.cn/v1/audio/transcriptions) 422
[01:29:26] [ForkJoinPool.commonPool-worker-6/INFO]: [CHAT] 接收语音识别请求时出错：HTTP Error Code: 422, Response (POST https://api.siliconflow.cn/v1/audio/transcriptions) 422
[01:29:26] [ForkJoinPool.commonPool-worker-6/ERROR]: STT request failed: https://api.siliconflow.cn/v1/audio/transcriptions POST, error is HTTP Error Code: 422, Response (POST https://api.siliconflow.cn/v1/audio/transcriptions) 422
```

## Temp Test Log
```
[1] Searching for microphone...
Using Microphone: interface TargetDataLine supporting 8 audio formats, and buffers of at least 32 bytes
Starting recording in 1 second...
>>> RECORDING... Speak now! (Press ENTER to stop)

Recorded 102400 bytes of PCM data.
Converted to WAV: 102444 bytes.

[2] Preparing Request...
Boundary Value: 6172902677494601970547235033740768352608851287786441255127032078105909582344
Boundary Length: 76 chars
[3] Sending Request...

=== RESPONSE ===
Status Code: 422
Body: {"detail":[{"type":"missing","loc":["body","file"],"msg":"Field required","input":null}]}
```