### PR TITLE
Fix OpenAI reasoning chat compatibility

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAIClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAIClient.java
@@ -25,12 +25,14 @@ import com.google.common.net.MediaType;
 import net.minecraft.server.level.ServerPlayer;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 
 public final class LLMOpenAIClient implements LLMClient {
     private static final Duration MAX_TIMEOUT = Duration.ofSeconds(60);
@@ -52,10 +54,23 @@ public final class LLMOpenAIClient implements LLMClient {
         int maxTokens = config.maxTokens();
         EntityMaid maid = config.maid();
         ChatType chatType = config.chatType();
+        OpenAIChatCompatibility compatibility = OpenAIChatCompatibility.from(this.site.url(), model);
 
         // 构建对话
-        ChatCompletion chatCompletion = ChatCompletion.create().model(model).maxTokens(maxTokens)
-                .temperature(temperature).setResponseFormat(ResponseFormat.text());
+        ChatCompletion chatCompletion = ChatCompletion.create().model(model).setResponseFormat(ResponseFormat.text());
+        if (compatibility.useMaxCompletionTokens()) {
+            chatCompletion.maxCompletionTokens(maxTokens);
+        } else {
+            chatCompletion.maxTokens(maxTokens);
+        }
+        if (compatibility.sendTemperature()) {
+            chatCompletion.temperature(temperature);
+        } else {
+            chatCompletion.clearTemperature();
+        }
+        if (compatibility.defaultReasoningEffort() != null) {
+            chatCompletion.reasoningEffort(compatibility.defaultReasoningEffort());
+        }
         // 添加消息
         for (LLMMessage message : messages) {
             if (message.role() == Role.USER) {
@@ -67,7 +82,11 @@ public final class LLMOpenAIClient implements LLMClient {
                     chatCompletion.assistantChat(message.message(), message.toolCalls());
                 }
             } else if (message.role() == Role.SYSTEM) {
-                chatCompletion.systemChat(message.message());
+                if (compatibility.useDeveloperMessages()) {
+                    chatCompletion.developerChat(message.message());
+                } else {
+                    chatCompletion.systemChat(message.message());
+                }
             } else if (message.role() == Role.TOOL) {
                 chatCompletion.toolChat(message.message(), message.toolCallId());
             }
@@ -149,5 +168,33 @@ public final class LLMOpenAIClient implements LLMClient {
             return;
         }
         callback.onSuccess(new ResponseChat(content));
+    }
+
+    private record OpenAIChatCompatibility(boolean useDeveloperMessages,
+                                           boolean useMaxCompletionTokens,
+                                           boolean sendTemperature,
+                                           @Nullable String defaultReasoningEffort) {
+        private static final OpenAIChatCompatibility DEFAULT =
+                new OpenAIChatCompatibility(false, false, true, null);
+
+        private static OpenAIChatCompatibility from(String url, String model) {
+            String normalizedUrl = StringUtils.defaultString(url).toLowerCase(Locale.ROOT);
+            String normalizedModel = StringUtils.defaultString(model).toLowerCase(Locale.ROOT);
+
+            if (!normalizedUrl.contains("api.openai.com")) {
+                return DEFAULT;
+            }
+
+            boolean isReasoningFamily = normalizedModel.startsWith("gpt-5")
+                    || normalizedModel.startsWith("o1")
+                    || normalizedModel.startsWith("o3")
+                    || normalizedModel.startsWith("o4");
+            if (!isReasoningFamily) {
+                return DEFAULT;
+            }
+
+            String reasoningEffort = normalizedModel.startsWith("gpt-5-pro") ? "high" : "medium";
+            return new OpenAIChatCompatibility(true, true, false, reasoningEffort);
+        }
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAISite.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAISite.java
@@ -125,7 +125,10 @@ public final class LLMOpenAISite implements LLMSite, SupportModelSelect {
                     "https://api.openai.com/v1/chat/completions", false,
                     StringUtils.EMPTY, Map.of(),
                     List.of("gpt-4o", "chatgpt-4o-latest", "gpt-4o-mini",
-                            "o1", "o1-mini", "o3-mini", "o1-preview"));
+                            "gpt-5", "gpt-5-mini", "gpt-5-nano",
+                            "gpt-5.2", "gpt-5.2-chat-latest",
+                            "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-chat-latest",
+                            "o1", "o1-mini", "o3-mini", "o4-mini", "o1-preview"));
         }
 
         @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatCompletion.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatCompletion.java
@@ -20,10 +20,16 @@ public class ChatCompletion {
     private ResponseFormat responseFormat = ResponseFormat.text();
 
     @SerializedName("max_tokens")
-    private int maxTokens = 4096;
+    private Integer maxTokens = 4096;
+
+    @SerializedName("max_completion_tokens")
+    private Integer maxCompletionTokens = null;
 
     @SerializedName("temperature")
-    private double temperature = 0.5;
+    private Double temperature = 0.5;
+
+    @SerializedName("reasoning_effort")
+    private String reasoningEffort = null;
 
     public static ChatCompletion create() {
         return new ChatCompletion();
@@ -36,6 +42,11 @@ public class ChatCompletion {
 
     public ChatCompletion systemChat(String message) {
         this.messages.add(ChatMessage.systemChat(message));
+        return this;
+    }
+
+    public ChatCompletion developerChat(String message) {
+        this.messages.add(ChatMessage.developerChat(message));
         return this;
     }
 
@@ -69,6 +80,13 @@ public class ChatCompletion {
 
     public ChatCompletion maxTokens(int maxTokens) {
         this.maxTokens = maxTokens;
+        this.maxCompletionTokens = null;
+        return this;
+    }
+
+    public ChatCompletion maxCompletionTokens(int maxCompletionTokens) {
+        this.maxCompletionTokens = maxCompletionTokens;
+        this.maxTokens = null;
         return this;
     }
 
@@ -78,8 +96,18 @@ public class ChatCompletion {
         return this;
     }
 
+    public ChatCompletion clearTemperature() {
+        this.temperature = null;
+        return this;
+    }
+
     public ChatCompletion setResponseFormat(ResponseFormat responseFormat) {
         this.responseFormat = responseFormat;
+        return this;
+    }
+
+    public ChatCompletion reasoningEffort(String reasoningEffort) {
+        this.reasoningEffort = reasoningEffort;
         return this;
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatMessage.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatMessage.java
@@ -26,6 +26,10 @@ public class ChatMessage {
         return new ChatMessage(Role.SYSTEM.getId(), content);
     }
 
+    public static ChatMessage developerChat(String content) {
+        return new ChatMessage("developer", content);
+    }
+
     public static ChatMessage userChat(String content) {
         return new ChatMessage(Role.USER.getId(), content);
     }


### PR DESCRIPTION
## Summary
- detect official OpenAI reasoning-family models on `api.openai.com`
- send `developer` messages and `max_completion_tokens` for those models
- omit unsupported `temperature`, add default `reasoning_effort`, and refresh default model suggestions

Further break down at #1075 

## Testing
- `GRADLE_USER_HOME=/tmp/tlm-gradle ./gradlew compileJava`