### PR TITLE
BUG修复:修复女仆因为其他mod多出手，导致的一系列bug

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidBreathAirTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidBreathAirTask.java
@@ -6,6 +6,7 @@ import com.github.tartaricacid.touhoulittlemaid.init.InitItems;
 import com.github.tartaricacid.touhoulittlemaid.inventory.handler.BaubleItemHandler;
 import com.github.tartaricacid.touhoulittlemaid.network.NetworkHandler;
 import com.github.tartaricacid.touhoulittlemaid.network.message.SpawnParticleMessage;
+import com.github.tartaricacid.touhoulittlemaid.util.HandUtils;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Pair;
@@ -99,7 +100,7 @@ public class MaidBreathAirTask extends Behavior<EntityMaid> {
 
     private boolean eatBreatheItem(EntityMaid maid) {
         // 先查询手部的物品能否吃：能就直接开吃，否就进行后续工作
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             ItemStack itemInHand = maid.getItemInHand(hand);
             if (itemInHand.isEmpty()) {
                 continue;
@@ -112,7 +113,7 @@ public class MaidBreathAirTask extends Behavior<EntityMaid> {
 
         // 对手部进行处理：如果没有空的手部，那就取副手
         InteractionHand eanHand = InteractionHand.OFF_HAND;
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             if (maid.getItemInHand(hand).isEmpty()) {
                 eanHand = hand;
                 break;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHealSelfTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHealSelfTask.java
@@ -5,6 +5,7 @@ import com.github.tartaricacid.touhoulittlemaid.api.task.meal.MaidMealType;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.DefaultMaidHealSelfMeal;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
+import com.github.tartaricacid.touhoulittlemaid.util.HandUtils;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.server.level.ServerLevel;
@@ -37,7 +38,7 @@ public class MaidHealSelfTask extends MaidCheckRateTask {
         List<IMaidMeal> maidMeals = MaidMealManager.getMaidMeals(MaidMealType.HEAL_MEAL);
 
         // 先查询手部的物品能否吃：能就直接开吃，否就进行后续工作
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             ItemStack itemInHand = maid.getItemInHand(hand);
 
             if (itemInHand.isEmpty()) {
@@ -54,7 +55,7 @@ public class MaidHealSelfTask extends MaidCheckRateTask {
 
         // 对手部进行处理：如果没有空的手部，那就取副手
         InteractionHand eanHand = InteractionHand.OFF_HAND;
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             if (maid.getItemInHand(hand).isEmpty()) {
                 eanHand = hand;
                 break;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHomeMealTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidHomeMealTask.java
@@ -9,6 +9,7 @@ import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
 import com.github.tartaricacid.touhoulittlemaid.init.InitTrigger;
 import com.github.tartaricacid.touhoulittlemaid.tileentity.TileEntityPicnicMat;
+import com.github.tartaricacid.touhoulittlemaid.util.HandUtils;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -63,7 +64,7 @@ public class MaidHomeMealTask extends MaidCheckRateTask {
 
         // 对手部进行处理：如果没有空的手部，那就取副手
         InteractionHand eanHand = InteractionHand.OFF_HAND;
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             if (maid.getItemInHand(hand).isEmpty()) {
                 eanHand = hand;
                 break;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/entity/ai/brain/task/MaidWorkMealTask.java
@@ -7,6 +7,7 @@ import com.github.tartaricacid.touhoulittlemaid.entity.favorability.Type;
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.DefaultMaidWorkMeal;
 import com.github.tartaricacid.touhoulittlemaid.entity.task.meal.MaidMealManager;
+import com.github.tartaricacid.touhoulittlemaid.util.HandUtils;
 import com.github.tartaricacid.touhoulittlemaid.util.ItemsUtil;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.server.level.ServerLevel;
@@ -38,7 +39,7 @@ public class MaidWorkMealTask extends MaidCheckRateTask {
         List<IMaidMeal> maidMeals = MaidMealManager.getMaidMeals(MaidMealType.WORK_MEAL);
 
         // 先查询手部的物品能否吃：能就直接开吃，否就进行后续工作
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             ItemStack itemInHand = maid.getItemInHand(hand);
 
             if (itemInHand.isEmpty()) {
@@ -55,7 +56,7 @@ public class MaidWorkMealTask extends MaidCheckRateTask {
 
         // 对手部进行处理：如果没有空的手部，那就取副手
         InteractionHand eanHand = InteractionHand.OFF_HAND;
-        for (InteractionHand hand : InteractionHand.values()) {
+        for (InteractionHand hand : HandUtils.NATIVE_HANDS) {
             if (maid.getItemInHand(hand).isEmpty()) {
                 eanHand = hand;
                 break;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/HandUtils.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/util/HandUtils.java
@@ -1,0 +1,12 @@
+package com.github.tartaricacid.touhoulittlemaid.util;
+
+import net.minecraft.world.InteractionHand;
+import java.util.Arrays;
+import java.util.List;
+
+public class HandUtils {
+    public static final List<InteractionHand> NATIVE_HANDS = Arrays.asList(
+        InteractionHand.MAIN_HAND,
+        InteractionHand.OFF_HAND
+    );
+}


### PR DESCRIPTION
解决Issues：[Issues1072](https://github.com/TartaricAcid/TouhouLittleMaid/issues/1072) 当中提到的bug

问题来源：
Accessorify这个mod，封装了一个方法如下
```
public class InteractionHandMixin {

	@Shadow @Final @Mutable private static InteractionHand[] $VALUES;

	@Invoker("<init>")
	static InteractionHand invokeInit(String name, int id) {
		throw new UnsupportedOperationException();
	}

	static {
		if (Accessorify.CONFIG.accessorySettings.totemOfUndyingAccessory.get()) {
			ArrayList<InteractionHand> list = new ArrayList<>(Arrays.asList($VALUES));
			int size = list.size();
			FakeHandHolder.FAKE_HAND = invokeInit("FAKE_HAND", size);
			list.add(FakeHandHolder.FAKE_HAND);
			$VALUES = list.toArray(new InteractionHand[size + 1]);
		}
	}
}
```

这个方法和女仆原本的一些地方使用的方法
InteractionHand.values()起了冲突，Accessorify为游戏添加了一只名为FAKE_HAND的手，如果使用这个方法去遍历枚举，就会导致多遍历一双手，女仆原本的逻辑是将食物移动到副手，就变为了移动到这个名为FAKE的手上，导致了食物直接整组消失

修复方法：
添加了一个HandUtils类，直接固定女仆只找寻原版的双手MAID和OFF，将原先所有使用InteractionHand.values()的地方改为了HandUtils.NATIVE_HANDS，以此解决该问题，并附带解决后gif

![71f11f83856589d0c1e11608b81973f9](https://github.com/user-attachments/assets/0b4184e3-7c04-4b44-b07f-d728cfbd5759)


和原bug视频链接
[BUG演示视频](https://www.bilibili.com/video/BV1CCc6zuECq?pop_share=1&spm_id_from=333.788.videopod.episodes&vd_source=40a6f6890596d3ff1eaf45c9dae77770)