### PR TITLE
完善 TTS 基础模型切换配置 & 优化多女仆 LLM 缓存隔离

### DIFF
--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/entity/LLMCallback.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/entity/LLMCallback.java
@@ -116,6 +116,17 @@ public class LLMCallback implements ResponseCallback<ResponseChat> {
     }
 
     /**
+     * 用于部分站点（如 DeepSeek、OpenRouter）的前缀缓存隔离，避免主对话与子 agent 对话
+     * （如知识库问答的 {@code GroundedAnswerCallback}）共用同一个缓存路由 / KVCache 槽位，
+     * 相互刷新导致缓存命中率下降。
+     * <p>
+     * 默认使用女仆的 UUID 作为主对话的隔离键，子 agent 回调应当覆盖此方法返回一个不同的键。
+     */
+    public String cacheIsolationKey() {
+        return maid.getStringUUID();
+    }
+
+    /**
      * 当前是否运行在服务端主线程。
      * <p>
      * 若当前上下文不在 {@link ServerLevel}，则返回 {@code false}。

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/entity/grounded/GroundedAnswerCallback.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/manager/entity/grounded/GroundedAnswerCallback.java
@@ -47,6 +47,12 @@ public class GroundedAnswerCallback extends LLMCallback {
     }
 
     @Override
+    public String cacheIsolationKey() {
+        // 子 agent 使用独立的隔离键，避免与主对话共用缓存路由，相互冲刷前缀缓存
+        return super.cacheIsolationKey() + "-grounded";
+    }
+
+    @Override
     public void onFunctionCall(Message choice, LLMClient client) {
         // 知识库回答时不处理函数调用，直接忽略（理论上也不会触发此回调）
     }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAIClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/LLMOpenAIClient.java
@@ -113,6 +113,17 @@ public class LLMOpenAIClient implements LLMClient {
             chatCompletion.mergeSystemMessages();
         }
 
+        // 部分站点支持通过隔离键将不同的逻辑对话路由到独立的前缀缓存 / KVCache 槽位，
+        // 避免主对话与子 agent 对话（如知识库问答）共用同一份缓存，相互冲刷导致命中率下降
+        String cacheIsolationKey = callback.cacheIsolationKey();
+        if (this.site.id().equals(DefaultLLMSite.DEEPSEEK.id())) {
+            // https://api-docs.deepseek.com/zh-cn/quick_start/rate_limit
+            chatCompletion.userId(cacheIsolationKey);
+        } else if (this.site.id().equals(DefaultLLMSite.OPEN_ROUTER.id())) {
+            // https://openrouter.ai/docs/guides/overview/models
+            chatCompletion.sessionId(cacheIsolationKey);
+        }
+
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatCompletion.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/llm/openai/request/ChatCompletion.java
@@ -26,6 +26,22 @@ public class ChatCompletion {
     @SerializedName("thinking")
     private Thinking thinking = null;
 
+    /**
+     * DeepSeek 专用，用于 KVCache 隔离，避免主对话与子 agent 对话相互冲刷前缀缓存
+     * <p>
+     * https://api-docs.deepseek.com/zh-cn/quick_start/rate_limit
+     */
+    @SerializedName("user_id")
+    private String userId = null;
+
+    /**
+     * OpenRouter 专用，用于 Provider Sticky Routing，避免主对话与子 agent 对话相互冲刷前缀缓存
+     * <p>
+     * https://openrouter.ai/docs/guides/overview/models
+     */
+    @SerializedName("session_id")
+    private String sessionId = null;
+
     public static ChatCompletion create() {
         return new ChatCompletion();
     }
@@ -75,6 +91,16 @@ public class ChatCompletion {
 
     public ChatCompletion disableThinking() {
         this.thinking = Thinking.disabled();
+        return this;
+    }
+
+    public ChatCompletion userId(String userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public ChatCompletion sessionId(String sessionId) {
+        this.sessionId = sessionId;
         return this;
     }
 

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/fishaudio/TTSFishAudioClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/fishaudio/TTSFishAudioClient.java
@@ -45,11 +45,8 @@ public class TTSFishAudioClient implements TTSClient {
                 .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(request)))
                 .timeout(MAX_TIMEOUT).uri(url);
 
-        // 2026/05/03：最近 Fish Audio 升级了接口，必须要带一个 model 参数
-        if (!this.site.headers().containsKey("model")) {
-            builder.header("model", "s2-pro");
-        }
         this.site.headers().forEach(builder::header);
+        builder.setHeader("model", this.site.siteModel());
         HttpRequest httpRequest = builder.build();
 
         httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/fishaudio/TTSFishAudioSite.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/fishaudio/TTSFishAudioSite.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
     public static final String API_TYPE = TTSApiType.FISH_AUDIO.getName();
+    public static final String DEFAULT_SITE_MODEL = "s2.1-pro";
 
     private final String id;
     private final ResourceLocation icon;
@@ -25,14 +26,17 @@ public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
     private String url;
     private boolean enabled;
     private String secretKey;
+    private String siteModel;
 
     public TTSFishAudioSite(String id, ResourceLocation icon, String url, boolean enabled,
-                            String secretKey, Map<String, String> headers, Map<String, String> models) {
+                            String secretKey, String siteModel,
+                            Map<String, String> headers, Map<String, String> models) {
         this.id = id;
         this.icon = icon;
         this.url = url;
         this.enabled = enabled;
         this.secretKey = secretKey;
+        this.siteModel = StringUtils.defaultIfBlank(siteModel, headers.getOrDefault("model", DEFAULT_SITE_MODEL));
         this.headers = headers;
         this.models = models;
     }
@@ -71,6 +75,10 @@ public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
         return secretKey;
     }
 
+    public String siteModel() {
+        return siteModel;
+    }
+
     @Override
     public Map<String, String> headers() {
         return headers;
@@ -99,6 +107,10 @@ public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
         this.secretKey = secretKey;
     }
 
+    public void setSiteModel(String siteModel) {
+        this.siteModel = siteModel;
+    }
+
     public static class Serializer implements SerializableSite<TTSFishAudioSite> {
         public static final Codec<TTSFishAudioSite> CODEC = RecordCodecBuilder.create(instance -> instance.group(
                 Codec.STRING.fieldOf(ID).forGetter(TTSFishAudioSite::id),
@@ -106,6 +118,7 @@ public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
                 Codec.STRING.fieldOf(URL).forGetter(TTSFishAudioSite::url),
                 Codec.BOOL.fieldOf(ENABLED).forGetter(TTSFishAudioSite::enabled),
                 Codec.STRING.fieldOf(SECRET_KEY).forGetter(TTSFishAudioSite::secretKey),
+                Codec.STRING.optionalFieldOf(SITE_MODEL, StringUtils.EMPTY).forGetter(TTSFishAudioSite::siteModel),
                 Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf(HEADERS).forGetter(TTSFishAudioSite::headers),
                 Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf(MODELS).forGetter(TTSFishAudioSite::models)
         ).apply(instance, TTSFishAudioSite::new));
@@ -113,7 +126,7 @@ public final class TTSFishAudioSite implements TTSSite, SupportModelSelect {
         @Override
         public TTSFishAudioSite defaultSite() {
             return new TTSFishAudioSite(API_TYPE, SerializableSite.defaultIcon(API_TYPE),
-                    "https://api.fish.audio/v1/tts", false, StringUtils.EMPTY, Map.of(),
+                    "https://api.fish.audio/v1/tts", false, StringUtils.EMPTY, DEFAULT_SITE_MODEL, Map.of(),
                     Map.of("b2b2d0fa88ee44d789da28ebbd97421e", "Neuro-sama (EN)",
                             "4858e0be678c4449bf3a7646186edd42", "Nahida (EN)",
                             "1aacaeb1b840436391b835fd5513f4c4", "Furina (CN)",

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/gptsovits/TTSGptSovitsClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/gptsovits/TTSGptSovitsClient.java
@@ -6,14 +6,24 @@ import com.github.tartaricacid.touhoulittlemaid.ai.service.tts.TTSConfig;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 
+import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class TTSGptSovitsClient implements TTSClient {
     private static final Duration MAX_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration MODEL_SWITCH_TIMEOUT = Duration.ofSeconds(60);
+    private static final String SET_GPT_WEIGHTS = "set_gpt_weights";
+    private static final String SET_SOVITS_WEIGHTS = "set_sovits_weights";
 
     private final HttpClient httpClient;
     private final TTSGptSovitsSite site;
@@ -35,15 +45,52 @@ public class TTSGptSovitsClient implements TTSClient {
                 .setAuxRefAudioPaths(this.site.auxRefAudioPaths())
                 .setTextSplitMethod(this.site.textSplitMethod());
 
-        HttpRequest httpRequest = HttpRequest.newBuilder()
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.JSON_UTF_8.toString())
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + this.site.secretKey())
                 .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(request)))
                 .timeout(MAX_TIMEOUT)
-                .uri(uri).build();
+                .uri(uri);
 
-        httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
+        this.site.headers().forEach(builder::header);
+        HttpRequest httpRequest = builder.build();
+
+        CompletableFuture<Void> prepareModels = CompletableFuture.completedFuture(null);
+        if (isNotBlank(this.site.gptModelPath())) {
+            prepareModels = prepareModels.thenCompose(unused ->
+                    this.switchModel(SET_GPT_WEIGHTS, this.site.gptModelPath()));
+        }
+        if (isNotBlank(this.site.sovitsModelPath())) {
+            prepareModels = prepareModels.thenCompose(unused ->
+                    this.switchModel(SET_SOVITS_WEIGHTS, this.site.sovitsModelPath()));
+        }
+
+        prepareModels.thenCompose(unused ->
+                        httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray()))
                 .whenComplete((response, throwable) ->
                         handleResponse(callback, response, throwable, httpRequest));
+    }
+
+    private CompletableFuture<Void> switchModel(String endpoint, String modelPath) {
+        String encodedPath = URLEncoder.encode(modelPath, StandardCharsets.UTF_8);
+        URI uri = URI.create(this.site.url()).resolve("./%s?weights_path=%s".formatted(endpoint, encodedPath));
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + this.site.secretKey())
+                .GET()
+                .timeout(MODEL_SWITCH_TIMEOUT)
+                .uri(uri);
+
+        this.site.headers().forEach(builder::header);
+        HttpRequest request = builder.build();
+        return this.httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofByteArray())
+                .thenAccept(response -> {
+                    if (!isSuccessful(response)) {
+                        String responseBody = new String(response.body(), StandardCharsets.UTF_8);
+                        String message = "Failed to switch GPT-SoVITS model: HTTP %d, Response %s"
+                                .formatted(response.statusCode(), responseBody);
+                        throw new CompletionException(new IOException(message));
+                    }
+                });
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/gptsovits/TTSGptSovitsSite.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/gptsovits/TTSGptSovitsSite.java
@@ -26,13 +26,16 @@ public final class TTSGptSovitsSite implements TTSSite {
     private String url;
     private boolean enabled;
     private String secretKey;
+    private String gptModelPath;
+    private String sovitsModelPath;
     private String refAudioPath;
     private String promptText;
     private String promptLang;
     private String textSplitMethod;
 
     public TTSGptSovitsSite(String id, ResourceLocation icon, String url, boolean enabled,
-                            String secretKey, String refAudioPath,
+                            String secretKey, String gptModelPath, String sovitsModelPath,
+                            String refAudioPath,
                             String promptText, String promptLang,
                             String textSplitMethod, List<String> auxRefAudioPaths,
                             Map<String, String> headers) {
@@ -41,6 +44,8 @@ public final class TTSGptSovitsSite implements TTSSite {
         this.url = url;
         this.enabled = enabled;
         this.secretKey = secretKey;
+        this.gptModelPath = gptModelPath;
+        this.sovitsModelPath = sovitsModelPath;
         this.refAudioPath = refAudioPath;
         this.promptText = promptText;
         this.promptLang = promptLang;
@@ -81,6 +86,14 @@ public final class TTSGptSovitsSite implements TTSSite {
 
     public String secretKey() {
         return secretKey;
+    }
+
+    public String gptModelPath() {
+        return gptModelPath;
+    }
+
+    public String sovitsModelPath() {
+        return sovitsModelPath;
     }
 
     public String refAudioPath() {
@@ -126,6 +139,14 @@ public final class TTSGptSovitsSite implements TTSSite {
         this.secretKey = secretKey;
     }
 
+    public void setGptModelPath(String gptModelPath) {
+        this.gptModelPath = gptModelPath;
+    }
+
+    public void setSovitsModelPath(String sovitsModelPath) {
+        this.sovitsModelPath = sovitsModelPath;
+    }
+
     public void setRefAudioPath(String refAudioPath) {
         this.refAudioPath = refAudioPath;
     }
@@ -149,6 +170,8 @@ public final class TTSGptSovitsSite implements TTSSite {
                 Codec.STRING.fieldOf(URL).forGetter(TTSGptSovitsSite::url),
                 Codec.BOOL.fieldOf(ENABLED).forGetter(TTSGptSovitsSite::enabled),
                 Codec.STRING.fieldOf(SECRET_KEY).forGetter(TTSGptSovitsSite::secretKey),
+                Codec.STRING.optionalFieldOf("gpt_model_path", StringUtils.EMPTY).forGetter(TTSGptSovitsSite::gptModelPath),
+                Codec.STRING.optionalFieldOf("sovits_model_path", StringUtils.EMPTY).forGetter(TTSGptSovitsSite::sovitsModelPath),
                 Codec.STRING.fieldOf("ref_audio_path").forGetter(TTSGptSovitsSite::refAudioPath),
                 Codec.STRING.fieldOf("prompt_text").forGetter(TTSGptSovitsSite::promptText),
                 Codec.STRING.fieldOf("prompt_lang").forGetter(TTSGptSovitsSite::promptLang),
@@ -162,6 +185,7 @@ public final class TTSGptSovitsSite implements TTSSite {
             return new TTSGptSovitsSite(API_TYPE, SerializableSite.defaultIcon(API_TYPE),
                     "http://127.0.0.1:9880/tts", false,
                     StringUtils.EMPTY, StringUtils.EMPTY, StringUtils.EMPTY,
+                    StringUtils.EMPTY, StringUtils.EMPTY,
                     "zh", "cut1", List.of(), Map.of()
             );
         }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/siliconflow/TTSSiliconflowClient.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/siliconflow/TTSSiliconflowClient.java
@@ -30,7 +30,7 @@ public class TTSSiliconflowClient implements TTSClient {
         String voice = config.model();
 
         TTSSiliconflowRequest request = TTSSiliconflowRequest.create()
-                .setInput(message).setModel(TTSSiliconflowSite.VOICE_MODEL)
+                .setInput(message).setModel(this.site.siteModel())
                 .setVoice(voice);
 
         HttpRequest.Builder builder = HttpRequest.newBuilder()

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/siliconflow/TTSSiliconflowSite.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/ai/service/tts/siliconflow/TTSSiliconflowSite.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
     public static final String API_TYPE = TTSApiType.SILICONFLOW.getName();
-    public static final String VOICE_MODEL = "FunAudioLLM/CosyVoice2-0.5B";
+    public static final String DEFAULT_SITE_MODEL = "FunAudioLLM/CosyVoice2-0.5B";
 
     private final String id;
     private final ResourceLocation icon;
@@ -26,14 +26,17 @@ public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
     private String url;
     private boolean enabled;
     private String secretKey;
+    private String siteModel;
 
     public TTSSiliconflowSite(String id, ResourceLocation icon, String url, boolean enabled,
-                              String secretKey, Map<String, String> headers, Map<String, String> models) {
+                              String secretKey, String siteModel,
+                              Map<String, String> headers, Map<String, String> models) {
         this.id = id;
         this.icon = icon;
         this.url = url;
         this.enabled = enabled;
         this.secretKey = secretKey;
+        this.siteModel = StringUtils.defaultIfBlank(siteModel, DEFAULT_SITE_MODEL);
         this.headers = headers;
         this.models = models;
     }
@@ -72,6 +75,10 @@ public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
         return secretKey;
     }
 
+    public String siteModel() {
+        return siteModel;
+    }
+
     @Override
     public Map<String, String> headers() {
         return headers;
@@ -100,6 +107,10 @@ public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
         this.secretKey = secretKey;
     }
 
+    public void setSiteModel(String siteModel) {
+        this.siteModel = siteModel;
+    }
+
     public static class Serializer implements SerializableSite<TTSSiliconflowSite> {
         public static final Codec<TTSSiliconflowSite> CODEC = RecordCodecBuilder.create(instance -> instance.group(
                 Codec.STRING.fieldOf(ID).forGetter(TTSSiliconflowSite::id),
@@ -107,6 +118,7 @@ public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
                 Codec.STRING.fieldOf(URL).forGetter(TTSSiliconflowSite::url),
                 Codec.BOOL.fieldOf(ENABLED).forGetter(TTSSiliconflowSite::enabled),
                 Codec.STRING.fieldOf(SECRET_KEY).forGetter(TTSSiliconflowSite::secretKey),
+                Codec.STRING.optionalFieldOf(SITE_MODEL, StringUtils.EMPTY).forGetter(TTSSiliconflowSite::siteModel),
                 Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf(HEADERS).forGetter(TTSSiliconflowSite::headers),
                 Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf(MODELS).forGetter(TTSSiliconflowSite::models)
         ).apply(instance, TTSSiliconflowSite::new));
@@ -114,11 +126,12 @@ public class TTSSiliconflowSite implements TTSSite, SupportModelSelect {
         @Override
         public TTSSiliconflowSite defaultSite() {
             return new TTSSiliconflowSite(API_TYPE, SerializableSite.defaultIcon(API_TYPE),
-                    "https://api.siliconflow.cn/v1/audio/speech", false, StringUtils.EMPTY, Map.of(),
-                    Map.of(VOICE_MODEL + ":anna", "anna",
-                            VOICE_MODEL + ":bella", "bella",
-                            VOICE_MODEL + ":claire", "claire",
-                            VOICE_MODEL + ":diana", "diana"));
+                    "https://api.siliconflow.cn/v1/audio/speech", false, StringUtils.EMPTY,
+                    DEFAULT_SITE_MODEL, Map.of(),
+                    Map.of(DEFAULT_SITE_MODEL + ":anna", "anna",
+                            DEFAULT_SITE_MODEL + ":bella", "bella",
+                            DEFAULT_SITE_MODEL + ":claire", "claire",
+                            DEFAULT_SITE_MODEL + ":diana", "diana"));
         }
 
         @Override

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/FormField.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/FormField.java
@@ -18,6 +18,8 @@ public class FormField {
     public static final String HOT_WORD = "hot_word";
     public static final String REF_AUDIO_PATH = "ref_audio_path";
     public static final String PROMPT_TEXT = "prompt_text";
+    public static final String GPT_MODEL_PATH = "gpt_model_path";
+    public static final String SOVITS_MODEL_PATH = "sovits_model_path";
 
     public final String label;
     public final boolean editable;

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSFishAudioFormLayout.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSFishAudioFormLayout.java
@@ -11,12 +11,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.SECRET_KEY;
-import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.URL;
+import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.*;
 import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.Translations.*;
 
 /**
- * FishAudio TTS：URL + Secret Key + 模型列表
+ * FishAudio TTS：URL + Secret Key + 基础模型 + 音色模型列表
  */
 public class TTSFishAudioFormLayout extends TTSSiteFormLayout {
     public TTSFishAudioFormLayout(TTSSite sourceSite) {
@@ -28,7 +27,8 @@ public class TTSFishAudioFormLayout extends TTSSiteFormLayout {
         TTSFishAudioSite site = (TTSFishAudioSite) this.sourceSite;
         return List.of(
                 new FieldDescriptor(URL, site.url(), true, false),
-                new FieldDescriptor(SECRET_KEY, site.secretKey(), true, true)
+                new FieldDescriptor(SECRET_KEY, site.secretKey(), true, true),
+                new FieldDescriptor(MODEL, site.siteModel(), true, false)
         );
     }
 
@@ -55,11 +55,16 @@ public class TTSFishAudioFormLayout extends TTSSiteFormLayout {
             showStatus.accept(SECRET_KEY_IS_EMPTY);
             return null;
         }
-        if (models.isEmpty()) {
+        String siteModel = fieldValues.apply(MODEL);
+        if (StringUtils.isBlank(siteModel)) {
             showStatus.accept(MODEL_IS_EMPTY);
             return null;
         }
+        if (models.isEmpty()) {
+            showStatus.accept(VOICE_IS_EMPTY);
+            return null;
+        }
         return new TTSFishAudioSite(site.id(), site.icon(), url, site.enabled(),
-                fieldValues.apply(SECRET_KEY), site.headers(), models);
+                secretKey, siteModel, site.headers(), models);
     }
 }

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSGptSovitsFormLayout.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSGptSovitsFormLayout.java
@@ -19,7 +19,7 @@ import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai
 
 
 /**
- * GPT-SoVITS TTS：URL + Secret Key + 参考音频 + 提示文本 + 语言/切分选项
+ * GPT-SoVITS TTS：URL + Secret Key + GPT/SoVITS 模型 + 参考音频 + 提示文本 + 语言/切分选项
  */
 public class TTSGptSovitsFormLayout extends TTSSiteFormLayout {
     private static final List<String> PROMPT_LANG_OPTIONS = List.of("en", "zh", "jp", "auto");
@@ -41,6 +41,8 @@ public class TTSGptSovitsFormLayout extends TTSSiteFormLayout {
         return List.of(
                 new FieldDescriptor(URL, site.url(), true, false),
                 new FieldDescriptor(SECRET_KEY, site.secretKey(), true, true),
+                new FieldDescriptor(GPT_MODEL_PATH, site.gptModelPath(), true, false),
+                new FieldDescriptor(SOVITS_MODEL_PATH, site.sovitsModelPath(), true, false),
                 new FieldDescriptor(REF_AUDIO_PATH, site.refAudioPath(), true, false),
                 new FieldDescriptor(PROMPT_TEXT, site.promptText(), true, false)
         );
@@ -101,6 +103,8 @@ public class TTSGptSovitsFormLayout extends TTSSiteFormLayout {
         }
         return new TTSGptSovitsSite(site.id(), site.icon(), url, site.enabled(),
                 fieldValues.apply(SECRET_KEY),
+                fieldValues.apply(GPT_MODEL_PATH),
+                fieldValues.apply(SOVITS_MODEL_PATH),
                 fieldValues.apply(REF_AUDIO_PATH),
                 fieldValues.apply(PROMPT_TEXT),
                 this.promptLangValue,

--- a/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSSiliconflowFormLayout.java
+++ b/src/main/java/com/github/tartaricacid/touhoulittlemaid/client/gui/entity/maid/ai/layout/TTSSiliconflowFormLayout.java
@@ -11,12 +11,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.SECRET_KEY;
-import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.URL;
+import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.FormField.*;
 import static com.github.tartaricacid.touhoulittlemaid.client.gui.entity.maid.ai.Translations.*;
 
 /**
- * SiliconFlow TTS：URL + Secret Key + 模型列表
+ * SiliconFlow TTS：URL + Secret Key + 基础模型 + 音色列表
  */
 public class TTSSiliconflowFormLayout extends TTSSiteFormLayout {
     public TTSSiliconflowFormLayout(TTSSite sourceSite) {
@@ -28,7 +27,8 @@ public class TTSSiliconflowFormLayout extends TTSSiteFormLayout {
         TTSSiliconflowSite site = (TTSSiliconflowSite) this.sourceSite;
         return List.of(
                 new FieldDescriptor(URL, site.url(), true, false),
-                new FieldDescriptor(SECRET_KEY, site.secretKey(), true, true)
+                new FieldDescriptor(SECRET_KEY, site.secretKey(), true, true),
+                new FieldDescriptor(MODEL, site.siteModel(), true, false)
         );
     }
 
@@ -55,11 +55,16 @@ public class TTSSiliconflowFormLayout extends TTSSiteFormLayout {
             showStatus.accept(SECRET_KEY_IS_EMPTY);
             return null;
         }
-        if (models.isEmpty()) {
+        String siteModel = fieldValues.apply(MODEL);
+        if (StringUtils.isBlank(siteModel)) {
             showStatus.accept(MODEL_IS_EMPTY);
             return null;
         }
+        if (models.isEmpty()) {
+            showStatus.accept(VOICE_IS_EMPTY);
+            return null;
+        }
         return new TTSSiliconflowSite(site.id(), site.icon(), url, site.enabled(),
-                fieldValues.apply(SECRET_KEY), site.headers(), models);
+                secretKey, siteModel, site.headers(), models);
     }
 }

--- a/src/main/resources/assets/touhou_little_maid/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/en_us.json
@@ -50,6 +50,8 @@
   "ai.touhou_little_maid.chat.settings.hub.secret_id": "Secret ID",
   "ai.touhou_little_maid.chat.settings.hub.secret_key": "Secret Key",
   "ai.touhou_little_maid.chat.settings.hub.model": "Model",
+  "ai.touhou_little_maid.chat.settings.hub.gpt_model_path": "GPT Model Path",
+  "ai.touhou_little_maid.chat.settings.hub.sovits_model_path": "SoVITS Model Path",
   "ai.touhou_little_maid.chat.settings.hub.models": "Models",
   "ai.touhou_little_maid.chat.settings.hub.voices": "Voices",
   "ai.touhou_little_maid.chat.settings.hub.app_key": "App Key",

--- a/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid/lang/zh_cn.json
@@ -58,6 +58,8 @@
   "ai.touhou_little_maid.chat.settings.hub.model.reasoning": "思考模型",
   "ai.touhou_little_maid.chat.settings.hub.model.normal": "普通模型",
   "ai.touhou_little_maid.chat.settings.hub.model": "模型",
+  "ai.touhou_little_maid.chat.settings.hub.gpt_model_path": "GPT 模型路径",
+  "ai.touhou_little_maid.chat.settings.hub.sovits_model_path": "SoVITS 模型路径",
   "ai.touhou_little_maid.chat.settings.hub.voices": "声音列表",
   "ai.touhou_little_maid.chat.settings.hub.secret_id_is_empty": "秘钥 ID 不能为空",
   "ai.touhou_little_maid.chat.settings.hub.secret_key_is_empty": "秘钥不能为空",


### PR DESCRIPTION
## 变更内容

### 1. 完善 TTS 基础模型切换配置 (\5006a48f\)

- **FishAudio TTS**：添加基础模型切换支持，新增 \modelName\ 配置字段，修复客户端请求参数，建议自定义为 s2.1-pro-free（免费且能力高于之前固定的 s2.0-pro）
- **GptSovits TTS**：重构客户端请求，支持 \modelName\ 参数传递，完善站点配置
- **SiliconFlow TTS**：补全 \modelName\ 字段支持，优化站点配置
- **UI 布局**：更新三个 TTS 服务对应的表单布局，支持模型选择

### 2. 优化多女仆 LLM 缓存隔离 (\e1c5242\)

- 为 \LLMCallback\ 添加缓存隔离机制，确保多个女仆独立使用 LLM 时不互相冲刷前缀，从而大幅提升多女仆状态下的缓存命中
- \GroundedAnswerCallback\ 同步适配缓存隔离
- \LLMOpenAIClient\ 增加缓存隔离支持
- \ChatCompletion\ 请求类新增缓存隔离相关字段